### PR TITLE
small fix to set event number in HepMC writer (currently always 0)

### DIFF
--- a/examples/PythiaBrickTest.cc
+++ b/examples/PythiaBrickTest.cc
@@ -123,10 +123,12 @@ int main(int argc, char** argv)
   
   // Output
   auto writer= make_shared<JetScapeWriterAscii> ("test_out.dat");
+  jetscape->Add(writer);
+#ifdef USE_GZIP
   // same as JetScapeWriterAscii but gzipped
   auto writergz= make_shared<JetScapeWriterAsciiGZ> ("test_out.dat.gz");
-  jetscape->Add(writer);
   jetscape->Add(writergz);
+#endif
   // HEPMC3
 #ifdef USE_HEPMC
   auto hepmcwriter= make_shared<JetScapeWriterHepMC> ("test_out.hepmc");

--- a/src/framework/JetScapeWriterHepMC.cc
+++ b/src/framework/JetScapeWriterHepMC.cc
@@ -71,7 +71,7 @@ namespace Jetscape {
     // Have collected all vertices now, add them to the event
     for( auto v : vertices )      evt.add_vertex( v );
     INFO << " found " << vertices.size() << " vertices in the list";
-    
+    evt.set_event_number(GetCurrentEvent());
     write_event(evt);
     vertices.clear();
     hadronizationvertex=0;


### PR DESCRIPTION
The event number in the HepMC record was always zero, this pull request sets it to GetCurrentEvent() which seems to be the event number given by the generator.
PythiaBrickTest.cc did not compile out of the box, to enable gzipped output one needs to compile with -DUSE_GZIP which enables the writer JetScapeWriterStreamGZ in JetScapeWriterStream.h, using #ifdef USE_GZIP around the creation of the gzip writer makes this consistent
