### PR TITLE
Add a mutex base class for eloss modules.

### DIFF
--- a/examples/jetscape_init.xml
+++ b/examples/jetscape_init.xml
@@ -78,7 +78,7 @@
     <deltaT>0.1</deltaT>
     <formTime> -0.1</formTime>
     <maxT>20</maxT>
-
+    <mutex>ON</mutex>
 
     <Matter>
       <name>Matter</name>

--- a/src/framework/JetEnergyLoss.cc
+++ b/src/framework/JetEnergyLoss.cc
@@ -28,6 +28,7 @@
 #include "JetScapeSignalManager.h"
 #include "JetScapeWriterStream.h"
 #include "HardProcess.h"
+#include "JetScapeModuleMutex.h"
 
 #ifdef USE_HEPMC
 #include "JetScapeWriterHepMC.h"
@@ -103,8 +104,41 @@ void JetEnergyLoss::Init()
   JetScapeModuleBase::Init();
 
   INFO<<"Intialize JetEnergyLoss ..."; 
-  
-  tinyxml2::XMLElement *eloss= JetScapeXML::Instance()->GetXMLRoot()->FirstChildElement("Eloss" );  
+
+  tinyxml2::XMLElement *eloss= JetScapeXML::Instance()->GetXMLRoot()->FirstChildElement("Eloss" );
+  if ( !eloss ) {
+    WARN << "Couldn't find tag Eloss";
+    throw std::runtime_error ("Couldn't find tag Eloss");
+  }
+  tinyxml2::XMLElement *mutex=eloss->FirstChildElement("mutex");
+  if ( !mutex ) {
+    WARN << "Couldn't find tag Eloss -> mutex";
+    throw std::runtime_error ("Couldn't find tag Eloss -> mutex");
+  }
+
+  if (mutex)
+  {
+    string mutexOnString = mutex->GetText();
+    if(!mutexOnString.compare("ON"))
+    //Check mutual exclusion of Eloss Modules
+    {
+      if (GetNumberOfTasks()>1)
+      {
+        for(auto elossModule : GetTaskList())
+        {
+          shared_ptr<JetScapeModuleMutex> mutex_ptr = elossModule->GetMutex();  
+          if(mutex_ptr)
+          {
+            if(!(mutex_ptr->CheckMutex(GetTaskList())))
+            {
+	      WARN<<"Mutual exclusive Energy-Loss modules attached together!";
+              throw std::runtime_error("Fix it by attaching one of them.");
+	    }
+          }
+        } 
+      }
+    }
+  }  
 
   if (!eloss)
     {

--- a/src/framework/JetScapeModuleMutex.h
+++ b/src/framework/JetScapeModuleMutex.h
@@ -1,0 +1,24 @@
+#ifndef JETSCAPEMODULEMUTEX_H
+#define JETSCAPEMODULEMUTEX_H
+
+#include <vector>
+#include <memory>
+#include "JetScapeTask.h"
+
+using namespace std;
+using std::shared_ptr;
+
+
+namespace Jetscape
+{
+
+class JetScapeModuleMutex
+{
+  public:
+    virtual bool CheckMutex(vector<shared_ptr<JetScapeTask>> modules) = 0;
+
+};
+
+} // end namespace Jetscape
+
+#endif

--- a/src/framework/JetScapeTask.h
+++ b/src/framework/JetScapeTask.h
@@ -35,7 +35,7 @@ namespace Jetscape {
 
 // need forward declaration
 class JetScapeWriter;
-
+class JetScapeModuleMutex;
 class PartonPrinter;
 class Parton;
 
@@ -188,6 +188,14 @@ class JetScapeTask
    */
   const string GetId() const {return id;}
 
+  /** This function returns the mutex of a JetScapeTask.
+   */
+  const shared_ptr<JetScapeModuleMutex> GetMutex() const {return mutex;}
+
+  /** This function sets the "mutex" of a JetScapeTask.
+   */
+  void SetMutex(shared_ptr<JetScapeModuleMutex> m_mutex) {mutex=m_mutex;}
+
  private:
 
   // can be made sortabele to put in correct oder or via xml file ...
@@ -199,6 +207,8 @@ class JetScapeTask
   // if for example a search rather position ... (or always sort with predefined order!?)
 
   int my_task_number_;
+
+  shared_ptr<JetScapeModuleMutex> mutex;
   
 };
 

--- a/src/jet/AdSCFT.cc
+++ b/src/jet/AdSCFT.cc
@@ -22,7 +22,7 @@
 #include "tinyxml2.h"
 #include <iostream>
 #include <fstream>
-
+#include "AdSCFTMutex.h"
 #include "FluidDynamics.h"
 
 #define MAGENTA "\033[35m"
@@ -40,6 +40,10 @@ AdSCFT::AdSCFT()
 AdSCFT::~AdSCFT()
 {
   VERBOSE(8);
+
+  // create and set AdSCFT Mutex
+  auto adscft_mutex = make_shared<AdSCFTMutex>();
+  SetMutex(adscft_mutex);
 }
 
 void AdSCFT::Init()

--- a/src/jet/AdSCFTMutex.cc
+++ b/src/jet/AdSCFTMutex.cc
@@ -1,0 +1,35 @@
+#include <vector>
+#include <string>
+#include<iostream>
+#include <memory>
+
+#include "JetScapeTask.h"
+#include "AdSCFTMutex.h"
+
+using namespace std;
+using std::shared_ptr;
+using namespace Jetscape;
+
+AdSCFTMutex::AdSCFTMutex()
+{
+}
+
+AdSCFTMutex::~AdSCFTMutex()
+{
+}
+
+bool AdSCFTMutex::CheckMutex(vector<shared_ptr<JetScapeTask>> modules)
+{
+  bool isLbt = false;
+  bool isMartini = false;
+
+  for(auto module : modules)
+  {
+    string name = module->GetId();
+    if(!name.compare("LBT")) isLbt = true;
+    if(!name.compare("Martini")) isMartini = true;
+  }
+
+  if(isLbt || isMartini) return false;
+  return true;
+}

--- a/src/jet/AdSCFTMutex.h
+++ b/src/jet/AdSCFTMutex.h
@@ -1,0 +1,24 @@
+#ifndef ADSCFTMUTEX_H
+#define ADSCFTMUTEX_H
+
+#include <vector>
+#include <string>
+#include<iostream>
+#include <memory>
+
+#include "JetScapeTask.h"
+#include "JetScapeModuleMutex.h"
+
+using namespace Jetscape;
+using std::shared_ptr;
+
+
+class AdSCFTMutex : public JetScapeModuleMutex
+{
+  public:
+    AdSCFTMutex();
+    ~AdSCFTMutex();
+    bool CheckMutex(vector<shared_ptr<JetScapeTask>> modules);
+};
+
+#endif

--- a/src/jet/LBT.cc
+++ b/src/jet/LBT.cc
@@ -23,7 +23,7 @@
 #include <fstream>
 #include <iostream>
 #include <iomanip>
-
+#include "LBTMutex.h"
 #include "FluidDynamics.h"
 
 #define MAGENTA "\033[35m"
@@ -74,6 +74,10 @@ LBT::LBT()
 {
   SetId("LBT");
   VERBOSE(8);
+
+  // create and set LBT Mutex
+  auto lbt_mutex = make_shared<LBTMutex>();
+  SetMutex(lbt_mutex);
 }
 
 LBT::~LBT()

--- a/src/jet/LBTMutex.cc
+++ b/src/jet/LBTMutex.cc
@@ -1,0 +1,35 @@
+#include <vector>
+#include <string>
+#include<iostream>
+#include <memory>
+
+#include "JetScapeTask.h"
+#include "LBTMutex.h"
+
+using namespace std;
+using std::shared_ptr;
+using namespace Jetscape;
+
+LBTMutex::LBTMutex()
+{
+}
+
+LBTMutex::~LBTMutex()
+{
+}
+
+bool LBTMutex::CheckMutex(vector<shared_ptr<JetScapeTask>> modules)
+{
+  bool isMartini = false;
+  bool isAdscft = false;
+
+  for(auto module : modules)
+  {
+    string name = module->GetId();
+    if(!name.compare("Martini")) isMartini = true;
+    if(!name.compare("AdSCFT")) isAdscft = true;
+  }
+
+  if(isMartini || isAdscft) return false;
+  return true;
+}

--- a/src/jet/LBTMutex.h
+++ b/src/jet/LBTMutex.h
@@ -1,0 +1,25 @@
+#ifndef LBTMUTEX_H
+#define LBTMUTEX_H
+
+#include <vector>
+#include <string>
+#include<iostream>
+#include <memory>
+
+#include "JetScapeTask.h"
+#include "JetScapeModuleMutex.h"
+
+using namespace Jetscape;
+using std::shared_ptr;
+
+
+class LBTMutex : public JetScapeModuleMutex
+{
+  public:
+    LBTMutex();
+    ~LBTMutex();
+    bool CheckMutex(vector<shared_ptr<JetScapeTask>> modules);
+
+};
+
+#endif

--- a/src/jet/Martini.cc
+++ b/src/jet/Martini.cc
@@ -20,7 +20,7 @@
 
 #include "tinyxml2.h"
 #include<iostream>
-
+#include "MartiniMutex.h"
 #include "FluidDynamics.h"
 #define hbarc 0.197327053
 
@@ -44,6 +44,10 @@ Martini::Martini()
   dGamma_qg = new vector<double>;
   dGamma_qq_q = new vector<double>;
   dGamma_qg_q = new vector<double>;
+
+  // create and set Martini Mutex
+  auto martini_mutex = make_shared<MartiniMutex>();
+  SetMutex(martini_mutex);
 }
 
 Martini::~Martini()

--- a/src/jet/MartiniMutex.cc
+++ b/src/jet/MartiniMutex.cc
@@ -1,0 +1,35 @@
+#include <vector>
+#include <string>
+#include<iostream>
+#include <memory>
+
+#include "JetScapeTask.h"
+#include "MartiniMutex.h"
+
+using namespace std;
+using std::shared_ptr;
+using namespace Jetscape;
+  
+MartiniMutex::MartiniMutex()
+{
+}
+
+MartiniMutex::~MartiniMutex()
+{
+}
+
+bool MartiniMutex::CheckMutex(vector<shared_ptr<JetScapeTask>> modules)
+{
+  bool isLbt = false;
+  bool isAdscft = false;
+
+  for(auto module : modules)
+  {
+    string name = module->GetId();
+    if(!name.compare("LBT")) isLbt = true;
+    if(!name.compare("AdSCFT")) isAdscft = true;
+  }
+
+  if(isLbt || isAdscft) return false;
+  return true;    
+}

--- a/src/jet/MartiniMutex.h
+++ b/src/jet/MartiniMutex.h
@@ -1,0 +1,22 @@
+#ifndef MARTINIMUTEX_H
+#define MARTINIMUTEX_H
+
+#include <vector>
+#include <string>
+#include<iostream>
+#include <memory>
+#include "JetScapeTask.h"
+#include "JetScapeModuleMutex.h"
+
+using namespace Jetscape;
+using std::shared_ptr;
+
+class MartiniMutex : public JetScapeModuleMutex
+{
+  public:
+    MartiniMutex();
+    ~MartiniMutex();
+    bool CheckMutex(vector<shared_ptr<JetScapeTask>> modules);  
+};
+
+#endif


### PR DESCRIPTION
Add a mutex base class for eloss modules. Set the mutex for MARTINI, LBT and AdSCFT.
This class knows LBT, Martini and AdSCFT cannot be attached together. JetEnergyLoss calls a method of this class to check validity of its child tasks. No need to change test codes: brickTest, PythiaBrickTest,...