### PR TITLE
Removing PartonPrinter as the object in the middle for hadronization

### DIFF
--- a/examples/LBT_brickTest.cc
+++ b/examples/LBT_brickTest.cc
@@ -39,7 +39,6 @@
 #include "Brick.h"
 #include "GubserHydro.h"
 #include "PGun.h"
-#include "PartonPrinter.h"
 #include "HadronizationManager.h"
 #include "Hadronization.h"
 #include "ColoredHadronization.h"
@@ -94,9 +93,6 @@ int main(int argc, char** argv)
   jetscape->Add(jlossmanager);
 
   // Hadronization
-  // This helper module currently needs to be added for hadronization.
-  auto printer = make_shared<PartonPrinter> ();
-  jetscape->Add(printer);
   auto hadroMgr = make_shared<HadronizationManager> ();
   auto hadro = make_shared<Hadronization> ();
   auto hadroModule = make_shared<ColoredHadronization> ();

--- a/examples/MUSICTest.cc
+++ b/examples/MUSICTest.cc
@@ -39,7 +39,6 @@
 #include "TrentoInitial.h"
 #include "NullPreDynamics.h"
 #include "PGun.h"
-#include "PartonPrinter.h"
 #include "HadronizationManager.h"
 #include "Hadronization.h"
 #include "ColoredHadronization.h"
@@ -114,9 +113,6 @@ int main(int argc, char** argv)
   jetscape->Add(jlossmanager);
   
   // Hadronization
-  // This helper module currently needs to be added for hadronization.
-  auto printer = make_shared<PartonPrinter> ();
-  jetscape->Add(printer);
   auto hadroMgr = make_shared<HadronizationManager> ();
   auto hadro = make_shared<Hadronization> ();
   auto hadroModule = make_shared<ColoredHadronization> ();

--- a/examples/PythiaBrickTest.cc
+++ b/examples/PythiaBrickTest.cc
@@ -40,7 +40,6 @@
 #include "Brick.h"
 #include "GubserHydro.h"
 #include "PythiaGun.h"
-#include "PartonPrinter.h"
 #include "HadronizationManager.h"
 #include "Hadronization.h"
 #include "ColoredHadronization.h"
@@ -108,9 +107,6 @@ int main(int argc, char** argv)
 
   
   // Hadronization
-  // This helper module currently needs to be added for hadronization.
-  auto printer = make_shared<PartonPrinter> ();
-  jetscape->Add(printer);
   auto hadroMgr = make_shared<HadronizationManager> ();
   auto hadro = make_shared<Hadronization> ();
   auto hadroModule = make_shared<ColoredHadronization> ();

--- a/examples/SimpleValidate.cc
+++ b/examples/SimpleValidate.cc
@@ -29,7 +29,6 @@
 #include "Brick.h"
 #include "PGun.h"
 #include "ElossValidation.h"
-#include "PartonPrinter.h"
 #include "HadronizationManager.h"
 #include "Hadronization.h"
 #include "ColoredHadronization.h"

--- a/examples/brickTest.cc
+++ b/examples/brickTest.cc
@@ -39,7 +39,6 @@
 #include "Brick.h"
 #include "GubserHydro.h"
 #include "PGun.h"
-#include "PartonPrinter.h"
 #include "HadronizationManager.h"
 #include "Hadronization.h"
 #include "ColoredHadronization.h"
@@ -103,9 +102,6 @@ int main(int argc, char** argv)
 
   
   // Hadronization
-  // This helper module currently needs to be added for hadronization.
-  auto printer = make_shared<PartonPrinter> ();
-  jetscape->Add(printer);
   auto hadroMgr = make_shared<HadronizationManager> ();
   auto hadro = make_shared<Hadronization> ();
   auto hadroModule = make_shared<ColoredHadronization> ();

--- a/examples/freestream-milneTest.cc
+++ b/examples/freestream-milneTest.cc
@@ -35,7 +35,6 @@
 #include "TrentoInitial.h"
 #include "PGun.h"
 #include "PythiaGun.h"
-#include "PartonPrinter.h"
 //#include "HadronizationManager.h"
 //#include "Hadronization.h"
 //#include "ColoredHadronization.h"
@@ -98,8 +97,6 @@ int main(int argc, char** argv)
   // auto pGun= make_shared<PGun> ();
   auto pythiaGun= make_shared<PythiaGun> ();
 
-  auto printer = make_shared<PartonPrinter> ();
-
   //auto hadroMgr = make_shared<HadronizationManager> ();
   //auto hadro = make_shared<Hadronization> ();
   //auto hadroModule = make_shared<ColoredHadronization> ();
@@ -138,8 +135,6 @@ int main(int argc, char** argv)
 
   jetscape->Add(jlossmanager);
 
-
-  jetscape->Add(printer);
 
   //hadro->Add(hadroModule);
   //hadroMgr->Add(hadro);

--- a/examples/hydroJetTest.cc
+++ b/examples/hydroJetTest.cc
@@ -42,7 +42,6 @@
 #include "GubserHydro.h"
 #include "HydroFromFile.h"
 #include "PythiaGun.h"
-#include "PartonPrinter.h"
 #include "HadronizationManager.h"
 #include "Hadronization.h"
 #include "ColoredHadronization.h"
@@ -107,8 +106,6 @@ int main(int argc, char** argv)
 
   auto pythiaGun= make_shared<PythiaGun> ();
 
-  auto printer = make_shared<PartonPrinter> ();
-
   auto hadroMgr = make_shared<HadronizationManager> ();
   auto hadro = make_shared<Hadronization> ();
   auto hadroModule = make_shared<ColoredHadronization> ();
@@ -149,8 +146,6 @@ int main(int argc, char** argv)
   jlossmanager->Add(jloss);
   
   jetscape->Add(jlossmanager);
-
-  jetscape->Add(printer);
 
   hadro->Add(hadroModule);
   //hadro->Add(colorless);

--- a/examples/hydroJetTestPGun.cc
+++ b/examples/hydroJetTestPGun.cc
@@ -43,7 +43,6 @@
 #include "HydroFromFile.h"
 #include "PGun.h"
 #include "PythiaGun.h"
-#include "PartonPrinter.h"
 #include "HadronizationManager.h"
 #include "Hadronization.h"
 #include "ColoredHadronization.h"
@@ -110,8 +109,6 @@ int main(int argc, char** argv)
 
   //auto pythiaGun= make_shared<PythiaGun> ();
 
-  auto printer = make_shared<PartonPrinter> ();
-
   auto hadroMgr = make_shared<HadronizationManager> ();
   auto hadro = make_shared<Hadronization> ();
   auto hadroModule = make_shared<ColoredHadronization> ();
@@ -152,8 +149,6 @@ int main(int argc, char** argv)
   jlossmanager->Add(jloss);
   
   jetscape->Add(jlossmanager);
-
-  jetscape->Add(printer);
 
   hadro->Add(hadroModule);
   //hadro->Add(colorless);

--- a/src/framework/JetEnergyLoss.cc
+++ b/src/framework/JetEnergyLoss.cc
@@ -95,7 +95,8 @@ void JetEnergyLoss::Clear()
   VERBOSESHOWER(8);
   if (pShower)
     pShower->clear();
-  
+ 
+  this->final_Partons.clear(); 
   //inP=nullptr;pShower=nullptr; // kind of defeating the porpose of shared pointers somehow ...
 }
 
@@ -339,7 +340,13 @@ void JetEnergyLoss::Exec()
 	
        shared_ptr<PartonPrinter> pPrinter = JetScapeSignalManager::Instance()->GetPartonPrinterPointer().lock();
        if ( pPrinter ){
-	 pPrinter->GetFinalPartons2(pShower);
+	 pPrinter->GetFinalPartons(pShower);
+       }
+
+       shared_ptr<JetEnergyLoss> pEloss = JetScapeSignalManager::Instance()->GetEnergyLossPointer().lock();
+       if(pEloss)
+       {
+           GetFinalPartonsForEachShower(pShower);
        }
     }
   else
@@ -370,6 +377,9 @@ void JetEnergyLoss::PrintShowerInitiatingParton()
   //JSDEBUG<<inP->pid();
 }
 
-
+void JetEnergyLoss::GetFinalPartonsForEachShower(shared_ptr<PartonShower> shower)
+{
+  this->final_Partons.push_back(shower.get()->GetFinalPartons()); 
+}
 
 } // end namespace Jetscape

--- a/src/framework/JetEnergyLoss.h
+++ b/src/framework/JetEnergyLoss.h
@@ -180,6 +180,11 @@ class JetEnergyLoss : public JetScapeModuleBase, public std::enable_shared_from_
    */
   const bool GetSentInPartonsConnected() {return SentInPartonsConnected;}
 
+  void GetFinalPartonsForEachShower(shared_ptr<PartonShower> shower);
+
+  // The Slot method to send the vector of Hadronization module
+  void SendFinalStatePartons(vector<vector<shared_ptr<Parton>>>& fPartons) {fPartons = final_Partons;};
+
  private:
 
   double deltaT;
@@ -203,7 +208,8 @@ class JetEnergyLoss : public JetScapeModuleBase, public std::enable_shared_from_
   bool jetSignalConnected;
   bool edensitySignalConnected;
   
- 
+  // Vector of final state partons for each shower as a vector
+  vector<vector<shared_ptr<Parton>>> final_Partons;
 
 };
 

--- a/src/framework/JetEnergyLossManager.cc
+++ b/src/framework/JetEnergyLossManager.cc
@@ -76,6 +76,13 @@ void JetEnergyLossManager::Init()
 
   INFO<<"Connect JetEnergyLossManager Signal to Hard Process ...";
   JetScapeSignalManager::Instance()->ConnectGetHardPartonListSignal(shared_from_this());
+
+  // Set the pointer of JetEnergyLoss for making connections to hadronization module
+  for (auto it : GetTaskList())
+  {
+    if (dynamic_pointer_cast<JetEnergyLoss>(it))
+        JetScapeSignalManager::Instance()->SetEnergyLossPointer(dynamic_pointer_cast<JetEnergyLoss>(it));
+  }
 }
 
 

--- a/src/framework/JetScapeSignalManager.cc
+++ b/src/framework/JetScapeSignalManager.cc
@@ -46,10 +46,10 @@ void JetScapeSignalManager::ConnectGetHardPartonListSignal(shared_ptr<JetEnergyL
 
 void JetScapeSignalManager::ConnectGetFinalPartonListSignal(shared_ptr<HadronizationManager> hm) {
   if ( !hm->GetGetFinalPartonListConnected() ){
-    auto ppp = GetPartonPrinterPointer().lock();
-    if ( ppp ) {
-      hm->GetFinalPartonList.connect(ppp.get(),&PartonPrinter::PrintFinalPartons);
-      hm->SetGetFinalPartonListConnected(true);
+      auto elp = GetEnergyLossPointer().lock();
+      if ( elp ) {
+          hm->GetFinalPartonList.connect(elp.get(),&JetEnergyLoss::SendFinalStatePartons);
+          hm->SetGetFinalPartonListConnected(true);
     }
   }
 

--- a/src/framework/JetScapeSignalManager.h
+++ b/src/framework/JetScapeSignalManager.h
@@ -27,7 +27,7 @@
 #include "HardProcess.h"
 #include "JetScapeWriter.h"
 #include "PreequilibriumDynamics.h"
-
+#include "PartonPrinter.h"
 
 #include<iostream>
 #include<string>
@@ -68,7 +68,10 @@ class JetScapeSignalManager //: public sigslot::has_slots<sigslot::multi_threade
 
   void SetPartonPrinterPointer(shared_ptr<PartonPrinter> m_pprinter) {pprinter=m_pprinter;}
   weak_ptr<PartonPrinter> GetPartonPrinterPointer() {return pprinter;}
-  
+
+  void SetEnergyLossPointer(shared_ptr<JetEnergyLoss> m_eloss) {eloss=m_eloss;}
+  weak_ptr<JetEnergyLoss> GetEnergyLossPointer() {return eloss;}  
+
   void ConnectJetSignal(shared_ptr<JetEnergyLoss> j);
   void ConnectEdensitySignal(shared_ptr<JetEnergyLoss> j);
   void ConnectGetHydroCellSignal(shared_ptr<JetEnergyLoss> j);
@@ -105,6 +108,7 @@ class JetScapeSignalManager //: public sigslot::has_slots<sigslot::multi_threade
   weak_ptr<JetScapeWriter> writer;
   weak_ptr<HadronizationManager> hadro;
   weak_ptr<PartonPrinter> pprinter;
+  weak_ptr<JetEnergyLoss> eloss;
   
   int num_jet_signals=0;
   int num_edensity_signals=0;

--- a/src/framework/JetScapeTask.h
+++ b/src/framework/JetScapeTask.h
@@ -36,7 +36,6 @@ namespace Jetscape {
 // need forward declaration
 class JetScapeWriter;
 class JetScapeModuleMutex;
-class PartonPrinter;
 class Parton;
 
 class JetScapeTask 

--- a/src/jet/PartonPrinter.cc
+++ b/src/jet/PartonPrinter.cc
@@ -44,18 +44,14 @@ void PartonPrinter::Exec()
   VERBOSE(2) <<"Run PartonPrinter: print shower from event # "<<GetCurrentEvent()<<" ...";
 }
 
-void PartonPrinter::GetFinalPartons(shared_ptr<PartonShower> pShower, vector<shared_ptr<Parton>>& fPartons)
+void PartonPrinter::GetFinalPartons(shared_ptr<PartonShower> pShower)
 {
   if(pShower)
   {
-    vector<shared_ptr<Parton>> vPin;
     for(unsigned int ipart=0; ipart <  pShower.get()->GetFinalPartons().size(); ++ipart)
     {
-      fPartons.push_back( pShower.get()->GetFinalPartons().at(ipart));
-        dist_output << ipart << " " << fPartons.at(ipart)->pid() << " " << fPartons.at(ipart)->e() << " " << fPartons.at(ipart)->px() << " " << fPartons.at(ipart)->py() << " " << fPartons.at(ipart)->pz() << endl;
-      vPin.push_back( pShower.get()->GetFinalPartons().at(ipart));	
+        dist_output << ipart << " " << pShower.get()->GetFinalPartons().at(ipart)->pid() << " " << pShower.get()->GetFinalPartons().at(ipart)->e() << " " << pShower.get()->GetFinalPartons().at(ipart)->px() << " " << pShower.get()->GetFinalPartons().at(ipart)->py() << " " << pShower.get()->GetFinalPartons().at(ipart)->pz() << endl;
     }
-    this->pFinals.push_back(vPin);
   }
 }
 

--- a/src/jet/PartonPrinter.h
+++ b/src/jet/PartonPrinter.h
@@ -38,7 +38,7 @@ virtual void Exec() final;
 virtual void Clear();
     std::ofstream dist_output; ///< the output stream where events are saved to file
 
-void GetFinalPartons(shared_ptr<PartonShower> pShower, vector<shared_ptr<Parton>>& fPartons);
+void GetFinalPartons(shared_ptr<PartonShower> pShower);
 
 void GetFinalPartons2(shared_ptr<PartonShower> pShower);
 


### PR DESCRIPTION
This branch removes PartonPrinter as an object-in-the-middle for hadronization. Now it does not have to be attached for hadronization and eloss sends the final state partons to the Hadronization module directly.
PartonPrinter is removed from src/framework and moved to src/jet. One may attach PartonPrinter if they need to access to the final state partons.