### PR TITLE
Fix a bug in hadronization related to removing PartonPrinter.

### DIFF
--- a/src/framework/JetEnergyLoss.cc
+++ b/src/framework/JetEnergyLoss.cc
@@ -346,7 +346,7 @@ void JetEnergyLoss::Exec()
        shared_ptr<JetEnergyLoss> pEloss = JetScapeSignalManager::Instance()->GetEnergyLossPointer().lock();
        if(pEloss)
        {
-           GetFinalPartonsForEachShower(pShower);
+           pEloss->GetFinalPartonsForEachShower(pShower);
        }
     }
   else


### PR DESCRIPTION
Ensure that the final state partons are added to the same eloss pointer for hadronization.