### PR TITLE
Add more parameters in the MUSIC wrapper for JETSCAPE Summer School

### DIFF
--- a/config/jetscape_master.xml
+++ b/config/jetscape_master.xml
@@ -299,6 +299,8 @@
       <iSS_table_path>../external_packages/iSS/iSS_tables</iSS_table_path>
       <!-- file path for the default particle table files  -->
       <iSS_particle_table_path>../external_packages/iSS/iSS_tables</iSS_particle_table_path>
+      <!-- hadron species list  0: PDG 2005; 1: UrQMD; 2: SMASH -->
+      <afterburner_type>1</afterburner_type>
 
       <number_of_repeated_sampling>1</number_of_repeated_sampling>
       <Perform_resonance_decays>1</Perform_resonance_decays>

--- a/config/jetscape_master.xml
+++ b/config/jetscape_master.xml
@@ -220,13 +220,18 @@
       <!-- (only works for MUSIC evo files) -->
       <read_hydro_every_ntau>1</read_hydro_every_ntau>
     </hydro_from_file>
-    
+
     <!-- MUSIC  -->
     <MUSIC>
       <name>MUSIC</name>
       <MUSIC_input_file>music_input</MUSIC_input_file>
       <output_evolution_to_file>1</output_evolution_to_file>
       <shear_viscosity_eta_over_s>0.08</shear_viscosity_eta_over_s>
+      <T_dependent_Shear_to_S_ratio>0</T_dependent_Shear_to_S_ratio>
+      <eta_over_s_T_kink_in_GeV>0.16</eta_over_s_T_kink_in_GeV>
+      <eta_over_s_low_T_slope_in_GeV>0.</eta_over_s_low_T_slope_in_GeV>
+      <eta_over_s_high_T_slope_in_GeV>0.</eta_over_s_high_T_slope_in_GeV>
+      <eta_over_s_at_kink>0.08</eta_over_s_at_kink>
       <temperature_dependent_bulk_viscosity>0</temperature_dependent_bulk_viscosity>
       <zeta_over_s_max>0</zeta_over_s_max>
       <zeta_over_s_T_peak_in_GeV>0.18</zeta_over_s_T_peak_in_GeV>

--- a/config/jetscape_master.xml
+++ b/config/jetscape_master.xml
@@ -227,6 +227,12 @@
       <MUSIC_input_file>music_input</MUSIC_input_file>
       <output_evolution_to_file>1</output_evolution_to_file>
       <shear_viscosity_eta_over_s>0.08</shear_viscosity_eta_over_s>
+      <temperature_dependent_bulk_viscosity>0</temperature_dependent_bulk_viscosity>
+      <zeta_over_s_max>0</zeta_over_s_max>
+      <zeta_over_s_T_peak_in_GeV>0.18</zeta_over_s_T_peak_in_GeV>
+      <zeta_over_s_width_in_GeV>0.02</zeta_over_s_width_in_GeV>
+      <zeta_over_s_lambda_asymm>0.0</zeta_over_s_lambda_asymm>
+      <Include_second_order_terms>1</Include_second_order_terms>
       <freezeout_temperature>-1</freezeout_temperature>
       <Perform_CooperFrye_Feezeout>0</Perform_CooperFrye_Feezeout>
     </MUSIC>

--- a/config/jetscape_master.xml
+++ b/config/jetscape_master.xml
@@ -225,6 +225,7 @@
     <MUSIC>
       <name>MUSIC</name>
       <MUSIC_input_file>music_input</MUSIC_input_file>
+      <Initial_time_tau_0>0.5</Initial_time_tau_0>
       <output_evolution_to_file>1</output_evolution_to_file>
       <shear_viscosity_eta_over_s>0.08</shear_viscosity_eta_over_s>
       <T_dependent_Shear_to_S_ratio>0</T_dependent_Shear_to_S_ratio>

--- a/src/hadronization/iSpectraSamplerWrapper.cc
+++ b/src/hadronization/iSpectraSamplerWrapper.cc
@@ -52,6 +52,8 @@ void iSpectraSamplerWrapper::InitTask() {
       {"SoftParticlization", "iSS", "number_of_repeated_sampling"});
   int flag_perform_decays = GetXMLElementInt(
       {"SoftParticlization", "iSS", "Perform_resonance_decays"});
+  int afterburner_type = (
+      GetXMLElementInt({"SoftParticlization", "iSS", "afterburner_type"}));
 
   if (!boost_invariance) {
     hydro_mode = 2;
@@ -63,6 +65,8 @@ void iSpectraSamplerWrapper::InitTask() {
 
   // overwrite some parameters
   iSpectraSampler_ptr_->paraRdr_ptr->setVal("hydro_mode", hydro_mode);
+  iSpectraSampler_ptr_->paraRdr_ptr->setVal("afterburner_type",
+                                            afterburner_type);
   iSpectraSampler_ptr_->paraRdr_ptr->setVal("output_samples_into_files", 0);
   iSpectraSampler_ptr_->paraRdr_ptr->setVal("use_OSCAR_format", 0);
   iSpectraSampler_ptr_->paraRdr_ptr->setVal("use_gzip_format", 0);

--- a/src/hydro/MusicWrapper.cc
+++ b/src/hydro/MusicWrapper.cc
@@ -58,6 +58,10 @@ void MpiMusic::InitializeHydro(Parameter parameter_list) {
       GetXMLElementInt({"Hydro", "MUSIC", "output_evolution_to_file"}));
   music_hydro_ptr->set_parameter("output_movie_flag",
                                  static_cast<double>(flag_output_evo_to_file));
+  double tau_hydro = (
+          GetXMLElementDouble({"Hydro", "MUSIC", "Initial_time_tau_0"}));
+  music_hydro_ptr->set_parameter("Initial_time_tau_0", tau_hydro);
+
   double eta_over_s =
       GetXMLElementDouble({"Hydro", "MUSIC", "shear_viscosity_eta_over_s"});
   if (eta_over_s > 1e-6) {

--- a/src/hydro/MusicWrapper.cc
+++ b/src/hydro/MusicWrapper.cc
@@ -76,6 +76,20 @@ void MpiMusic::InitializeHydro(Parameter parameter_list) {
           {"Hydro", "MUSIC", "temperature_dependent_bulk_viscosity"});
   if (flag_bulkvis != 0) {
     music_hydro_ptr->set_parameter("Include_Bulk_Visc_Yes_1_No_0", 1);
+    music_hydro_ptr->set_parameter("T_dependent_Bulk_to_S_ratio", flag_bulkvis);
+    double bulk_max = GetXMLElementDouble(
+          {"Hydro", "MUSIC", "zeta_over_s_max"});
+    music_hydro_ptr->set_parameter("zeta_over_s_max", bulk_max);
+    double bulk_peakT = GetXMLElementDouble(
+          {"Hydro", "MUSIC", "zeta_over_s_T_peak_in_GeV"});
+    music_hydro_ptr->set_parameter("zeta_over_s_T_peak_in_GeV", bulk_peakT);
+    double bulk_width = GetXMLElementDouble(
+          {"Hydro", "MUSIC", "zeta_over_s_width_in_GeV"});
+    music_hydro_ptr->set_parameter("zeta_over_s_width_in_GeV", bulk_width);
+    double bulk_asy = GetXMLElementDouble(
+          {"Hydro", "MUSIC", "zeta_over_s_lambda_asymm"});
+    music_hydro_ptr->set_parameter("zeta_over_s_lambda_asymm", bulk_asy);
+
   }
 
   int flag_secondorderTerms = GetXMLElementInt(

--- a/src/hydro/MusicWrapper.cc
+++ b/src/hydro/MusicWrapper.cc
@@ -76,24 +76,51 @@ void MpiMusic::InitializeHydro(Parameter parameter_list) {
     exit(1);
   }
 
+  int flag_shear_Tdep = (
+      GetXMLElementInt({"Hydro", "MUSIC", "T_dependent_Shear_to_S_ratio"}));
+  if (flag_shear_Tdep > 0) {
+    music_hydro_ptr->set_parameter("Viscosity_Flag_Yes_1_No_0", 1);
+    if (flag_shear_Tdep == 3) {
+      double shear_kinkT = (
+        GetXMLElementDouble({"Hydro", "MUSIC", "eta_over_s_T_kink_in_GeV"}));
+      music_hydro_ptr->set_parameter("eta_over_s_T_kink_in_GeV", shear_kinkT);
+      double shear_lowTslope = (
+        GetXMLElementDouble({"Hydro", "MUSIC",
+                             "eta_over_s_low_T_slope_in_GeV"}));
+      music_hydro_ptr->set_parameter("eta_over_s_low_T_slope_in_GeV",
+                                     shear_lowTslope);
+      double shear_highTslope = (
+        GetXMLElementDouble({"Hydro", "MUSIC",
+                             "eta_over_s_high_T_slope_in_GeV"}));
+      music_hydro_ptr->set_parameter("eta_over_s_high_T_slope_in_GeV",
+                                     shear_highTslope);
+      double shear_kink = (
+        GetXMLElementDouble({"Hydro", "MUSIC", "eta_over_s_at_kink"}));
+      music_hydro_ptr->set_parameter("eta_over_s_at_kink", shear_kink);
+    }
+  }
+
   int flag_bulkvis = GetXMLElementInt(
           {"Hydro", "MUSIC", "temperature_dependent_bulk_viscosity"});
   if (flag_bulkvis != 0) {
     music_hydro_ptr->set_parameter("Include_Bulk_Visc_Yes_1_No_0", 1);
-    music_hydro_ptr->set_parameter("T_dependent_Bulk_to_S_ratio", flag_bulkvis);
-    double bulk_max = GetXMLElementDouble(
-          {"Hydro", "MUSIC", "zeta_over_s_max"});
-    music_hydro_ptr->set_parameter("zeta_over_s_max", bulk_max);
-    double bulk_peakT = GetXMLElementDouble(
-          {"Hydro", "MUSIC", "zeta_over_s_T_peak_in_GeV"});
-    music_hydro_ptr->set_parameter("zeta_over_s_T_peak_in_GeV", bulk_peakT);
-    double bulk_width = GetXMLElementDouble(
-          {"Hydro", "MUSIC", "zeta_over_s_width_in_GeV"});
-    music_hydro_ptr->set_parameter("zeta_over_s_width_in_GeV", bulk_width);
-    double bulk_asy = GetXMLElementDouble(
-          {"Hydro", "MUSIC", "zeta_over_s_lambda_asymm"});
-    music_hydro_ptr->set_parameter("zeta_over_s_lambda_asymm", bulk_asy);
-
+    music_hydro_ptr->set_parameter("T_dependent_Bulk_to_S_ratio",
+                                   flag_bulkvis);
+    if (flag_bulkvis == 3) {
+        double bulk_max = GetXMLElementDouble(
+              {"Hydro", "MUSIC", "zeta_over_s_max"});
+        music_hydro_ptr->set_parameter("zeta_over_s_max", bulk_max);
+        double bulk_peakT = GetXMLElementDouble(
+              {"Hydro", "MUSIC", "zeta_over_s_T_peak_in_GeV"});
+        music_hydro_ptr->set_parameter("zeta_over_s_T_peak_in_GeV",
+                                       bulk_peakT);
+        double bulk_width = GetXMLElementDouble(
+              {"Hydro", "MUSIC", "zeta_over_s_width_in_GeV"});
+        music_hydro_ptr->set_parameter("zeta_over_s_width_in_GeV", bulk_width);
+        double bulk_asy = GetXMLElementDouble(
+              {"Hydro", "MUSIC", "zeta_over_s_lambda_asymm"});
+        music_hydro_ptr->set_parameter("zeta_over_s_lambda_asymm", bulk_asy);
+    }
   }
 
   int flag_secondorderTerms = GetXMLElementInt(


### PR DESCRIPTION
I merged the parameterization of transport coefficientChun devs from the SIMS group into the public version of MUSIC and update the MUSIC wrapper in the JETSCAPE to allow users to pass parameters to change the temperature dependence of eta/s(T) and zeta/s(T). These modifications are useful for the hydro session during the JETSCAPE Summer School.