### PR TITLE
Bugfix: reset SMASH event index properly

### DIFF
--- a/src/afterburner/SmashWrapper.cc
+++ b/src/afterburner/SmashWrapper.cc
@@ -97,6 +97,10 @@ void SmashWrapper::InitTask() {
 
 void SmashWrapper::ExecuteTask() {
   AfterburnerModus *modus = smash_experiment_->modus();
+  // This is necessary to correctly handle indices of particle sets from hydro.
+  // Every hydro event creates a new structure like jetscape_hadrons_
+  // with as many events in it as one has samples per hydro
+  modus->reset_event_numbering();
   modus->jetscape_hadrons_ = soft_particlization_sampler_->Hadron_list_;
   const int n_events = modus->jetscape_hadrons_.size();
   JSINFO << "SMASH: obtained " << n_events << " events from particlization";

--- a/src/afterburner/SmashWrapper.h
+++ b/src/afterburner/SmashWrapper.h
@@ -39,6 +39,7 @@ public:
   AfterburnerModus(smash::Configuration, const smash::ExperimentParameters &) {
     JSINFO << "Constructing AfterburnerModus";
   }
+  void reset_event_numbering() { event_number_ = 0; }
   // The converter is not static, because modus holds int variables
   // for the number of warnings, which are used in try_create_particle,
   // called by this function. Maybe I (oliiny) will change this design in SMASH


### PR DESCRIPTION
For each hydro event there can be N sampler events. Particles from all N
sampler events are saved in a structure, which SMASH wrapper passes to SMASH.
Next hydro event executes new N sampler events and resets this structure, so
particles from previous hydro event are forgotten. SMASH wrapper didn't know
that and incremented the event number further instead of resetting it to 0 for
each new hydro event. That number was used as an array index, so for the second
hydro event it segfaulted.

This refs #55

Signed-off-by: Dmytro Oliinychenko <doliinychenko@lbl.gov>