### PR TITLE
Allow configuration of pre-equilibrium dynamics parameters via XML

### DIFF
--- a/external_packages/freestream-milne-external-params.patch
+++ b/external_packages/freestream-milne-external-params.patch
@@ -1,0 +1,87 @@
+Subject: [PATCH] External parameter control
+
+---
+ src/FileIO.cpp          |  6 ++----
+ src/FreestreamMilne.cpp | 27 ++++++++++++++++++---------
+ 2 files changed, 20 insertions(+), 13 deletions(-)
+
+diff --git src/FileIO.cpp src/FileIO.cpp
+index 58c6acf..d72db3c 100644
+--- src/FileIO.cpp
++++ src/FileIO.cpp
+@@ -163,7 +163,7 @@ void readDensityFile(float *density, char name[255], parameters params)
+   infile.close();
+ }
+ 
+-void readInParameters(struct parameters &params)
++void readInParameters(const char *filename, struct parameters &params)
+ {
+   char dummyChar[255];
+   int dummyInt;
+@@ -171,9 +171,7 @@ void readInParameters(struct parameters &params)
+   float dummyFloat;
+ 
+   FILE *fileIn;
+-  std::stringstream paramsStream;
+-  paramsStream << "freestream_input";
+-  fileIn = fopen(paramsStream.str().c_str(),"r");
++  fileIn = fopen(filename,"r");
+ 
+   if (fileIn == NULL)
+   {
+diff --git src/FreestreamMilne.cpp src/FreestreamMilne.cpp
+index 3bb12bc..7128164 100644
+--- src/FreestreamMilne.cpp
++++ src/FreestreamMilne.cpp
+@@ -34,6 +34,10 @@ class FREESTREAMMILNE {
+ 
+     int run_freestream_milne();
+ 
++    struct parameters params;
++
++    parameters * configure(const char * = "freestream_input");
++
+     // IS THIS VARIABLE NECESSARY
+     int gridSize; //the total number of grid points in x, y, and eta : used for vector memory allocation
+ 
+@@ -135,15 +139,9 @@ void FREESTREAMMILNE::output_to_vectors(std::vector<double> &energy_density_out,
+   Pi_out = final_Pi;
+ }
+ 
+-//where the magic happens
+-int FREESTREAMMILNE::run_freestream_milne() {
+-
+-float hbarc = 0.197326938;
+-
+-if(PRINT_SCREEN) printf("Welcome to freestream-milne\n");
+-
++parameters * FREESTREAMMILNE::configure(const char *filename) {
+ //declare parameter struct
+-struct parameters params;
++//struct parameters params;
+ 
+ //set default parameters in case of missing freestream_input file
+ params.OUTPUTFORMAT = 2;
+@@ -171,7 +169,18 @@ params.VISCOUS_MATCHING = 1;
+ params.E_DEP_FS = 0;
+ 
+ //read in chosen parameters from freestream_input if such a file exists
+-readInParameters(params);
++readInParameters(filename,params);
++
++return &params;
++
++}
++
++//where the magic happens
++int FREESTREAMMILNE::run_freestream_milne() {
++
++float hbarc = 0.197326938;
++
++if(PRINT_SCREEN) printf("Welcome to freestream-milne\n");
+ 
+ //define some useful combinations
+ params.DIM = params.DIM_X * params.DIM_Y * params.DIM_ETA;
+-- 
+2.28.0
+

--- a/external_packages/get_freestream-milne.sh
+++ b/external_packages/get_freestream-milne.sh
@@ -15,5 +15,8 @@
 
 # download the 3+1D OSU freestreaming code
 git clone --depth=1 https://github.com/derekeverett/freestream-milne.git freestream-milne
-#cd freestream-milne
+
+cd freestream-milne
+patch -p0 -Ni ../freestream-milne-external-params.patch
+
 #git checkout double_prec

--- a/src/preequilibrium/FreestreamMilneWrapper.cc
+++ b/src/preequilibrium/FreestreamMilneWrapper.cc
@@ -47,6 +47,15 @@ void FreestreamMilneWrapper::InitializePreequilibrium(
   //is this necessary? if we just force the user to have the 'freestream_input' file in the correct directory
 
   fsmilne_ptr = new FREESTREAMMILNE();
+  struct parameters *params = fsmilne_ptr->configure(input_file.c_str());
+
+  double tau0 = GetXMLElementDouble(
+      {"Preequilibrium", "tau0"});
+  double taus = GetXMLElementDouble(
+      {"Preequilibrium", "taus"});
+
+  params->TAU0 = tau0;
+  params->DTAU = taus;
 }
 
 void FreestreamMilneWrapper::EvolvePreequilibrium() {


### PR DESCRIPTION
Adds support for changing the freestreaming proper time via XML `<tau0> `and `<taus>`, and the name of the configuration file _freestream_input_ itself. The freestream-milne code is patched to support this immediately after downloading with `get_freestream-milne.sh`.