### PR TITLE
Fix sampling impact parameter

### DIFF
--- a/external_packages/trento/src/collider.cxx
+++ b/external_packages/trento/src/collider.cxx
@@ -130,7 +130,7 @@ double Collider::sample_impact_param() {
 
   do {
     // Sample b from P(b)db = 2*pi*b.
-    b = bmin_ + (bmax_ - bmin_) * std::sqrt(random::canonical<double>());
+    b = std::sqrt(bmin_ * bmin_ + (bmax_ * bmax_ - bmin_ * bmin_) * random::canonical<double>());
 
     // Offset each nucleus depending on the asymmetry parameter (see header).
     nucleusA_->sample_nucleons(asymmetry_ * b);


### PR DESCRIPTION
For getting the proper fraction of the cross section when the requested minimum value of the impact parameter is not zero
Same PR requested towards Trento2D