### PR TITLE
Modify Martini.cc to use the MUSIC hydro

### DIFF
--- a/src/framework/JetEnergyLoss.cc
+++ b/src/framework/JetEnergyLoss.cc
@@ -49,6 +49,7 @@ JetEnergyLoss::JetEnergyLoss() {
   jetSignalConnected = false;
   edensitySignalConnected = false;
   GetHydroCellSignalConnected = false;
+  GetHydroTau0SignalConnected = false;
   SentInPartonsConnected = false;
 
   deltaT = 0;
@@ -74,6 +75,7 @@ JetEnergyLoss::JetEnergyLoss(const JetEnergyLoss &j) {
   SetJetSignalConnected(false);
   SetEdensitySignalConnected(false);
   SetGetHydroCellSignalConnected(false);
+  SetGetHydroTau0SignalConnected(false);
   SetSentInPartonsConnected(false);
 
   deltaT = j.deltaT;

--- a/src/hydro/HydroFromFile.cc
+++ b/src/hydro/HydroFromFile.cc
@@ -136,6 +136,8 @@ void HydroFromFile::EvolveHydro() {
     }
 #ifdef USE_HDF5
     read_in_hydro_event(filename, 500, load_viscous_);
+    hydro_tau_0 = hydroinfo_h5_ptr->getHydrogridTau0();
+    hydro_tau_max = hydroinfo_h5_ptr->getHydrogridTaumax();
 #endif
     hydro_status = FINISHED;
   } else if (hydro_type_ == 2) {
@@ -159,6 +161,8 @@ void HydroFromFile::EvolveHydro() {
       hydro_ideal_file = hydro_filename.str();
     }
     read_in_hydro_event(input_file, hydro_ideal_file, nskip_tau_);
+    hydro_tau_0 = hydroinfo_MUSIC_ptr->get_hydro_tau0();
+    hydro_tau_max = hydroinfo_MUSIC_ptr->get_hydro_tau_max();
   } else if (hydro_type_ == 3) {
     string input_file;
     string hydro_ideal_file;
@@ -180,6 +184,8 @@ void HydroFromFile::EvolveHydro() {
       hydro_ideal_file = hydro_filename.str();
     }
     read_in_hydro_event(input_file, hydro_ideal_file, nskip_tau_);
+    hydro_tau_0 = hydroinfo_MUSIC_ptr->get_hydro_tau0();
+    hydro_tau_max = hydroinfo_MUSIC_ptr->get_hydro_tau_max();
   } else if (hydro_type_ == 4) {
     string input_file;
     string hydro_ideal_file;
@@ -201,6 +207,8 @@ void HydroFromFile::EvolveHydro() {
       hydro_ideal_file = hydro_filename.str();
     }
     read_in_hydro_event(input_file, hydro_ideal_file, 1);
+    hydro_tau_0 = hydroinfo_MUSIC_ptr->get_hydro_tau0();
+    hydro_tau_max = hydroinfo_MUSIC_ptr->get_hydro_tau_max();
   } else {
     JSWARN << "main: unrecognized hydro_type = " << hydro_type_;
     exit(1);

--- a/src/jet/AdSCFT.cc
+++ b/src/jet/AdSCFT.cc
@@ -83,6 +83,8 @@ void AdSCFT::DoEnergyLoss(double deltaT, double time, double Q2,
   VERBOSESHOWER(8) << MAGENTA << "SentInPartons Signal received : " << deltaT
                    << " " << Q2 << " " << &pIn;
 
+  GetHydroTau0Signal(tStart);
+
   for (int i = 0; i < pIn.size(); i++) {
     //Skip photons
     if (pIn[i].pid() == photonid) {

--- a/src/jet/AdSCFT.h
+++ b/src/jet/AdSCFT.h
@@ -47,7 +47,7 @@ public:
   void WriteTask(weak_ptr<JetScapeWriter> w);
 
 private:
-  double tStart = 0.6; //Hydro starting time
+  double tStart;       //Hydro starting time
   double T0;           //End of quenching temperature
   double Q0;           //Switching virtuality
   bool in_vac;         //In vacuum or not switch

--- a/src/jet/LBT.cc
+++ b/src/jet/LBT.cc
@@ -178,6 +178,9 @@ void LBT::DoEnergyLoss(double deltaT, double time, double Q2,
 
   //DEBUG:
   //cout<<" ---> "<<pIn.size()<<endl;
+
+  GetHydroTau0Signal(tStart);
+
   for (int i = 0; i < pIn.size(); i++) {
 
     // Reject photons

--- a/src/jet/LBT.h
+++ b/src/jet/LBT.h
@@ -319,7 +319,7 @@ private:
   int flagScatter, flag_update, flag_update0;
   double Q00, Q0;
 
-  double tStart = 0.6;
+  double tStart;
 
   //...functions
 

--- a/src/jet/Martini.cc
+++ b/src/jet/Martini.cc
@@ -84,7 +84,8 @@ void Martini::Init() {
 
   g = sqrt(4. * M_PI * alpha_s);
   alpha_em = 1. / 137.;
-  hydro_tStart = 0.6;
+  //hydro_tStart = 0.6;
+  hydro_tStart = 1.0;
 
   // Path to additional data
   PathToTables = GetXMLElementText({"Eloss", "Martini", "path"});
@@ -188,6 +189,10 @@ void Martini::DoEnergyLoss(double deltaT, double Time, double Q2,
     SpatialRapidity = 0.5 * std::log((tt + zz) / (tt - zz));
     double boostedTStart = hydro_tStart * cosh(SpatialRapidity);
 
+    // Only accept low t particles
+    if (pIn[i].t() > Q0 * Q0 + rounding_error || Time <= boostedTStart)
+      continue;
+
     // Extract fluid properties
     std::unique_ptr<FluidCellInfo> check_fluid_info_ptr;
     GetHydroCellSignal(Time, xx, yy, zz, check_fluid_info_ptr);
@@ -201,10 +206,8 @@ void Martini::DoEnergyLoss(double deltaT, double Time, double Q2,
 
     beta = sqrt(vx * vx + vy * vy + vz * vz);
 
-    // Only accept low t particles
-    if (pIn[i].t() > Q0 * Q0 + rounding_error || Time <= boostedTStart ||
-        T < hydro_Tc)
-      continue;
+    if (T < hydro_Tc) continue;
+
     TakeResponsibilityFor(
         pIn[i]); // Generate error if another module already has responsibility.
 

--- a/src/jet/Matter.cc
+++ b/src/jet/Matter.cc
@@ -248,6 +248,8 @@ void Matter::DoEnergyLoss(double deltaT, double time, double Q2,
 
   VERBOSE(8) << " qhat0 = " << qhat0 << " qhat = " << qhat;
 
+  GetHydroTau0Signal(tStart);
+
   for (int i = 0; i < pIn.size(); i++) {
 
     // Reject photons

--- a/src/jet/Matter.h
+++ b/src/jet/Matter.h
@@ -115,7 +115,7 @@ public:
   double qhatTab1D[dimQhatTab] = {0.0};
   double qhatTab2D[dimQhatTab][dimQhatTab] = {{0.0}};
 
-  double tStart = 0.6;
+  double tStart;
   int iEvent;
   bool debug_flag = 0;
   long NUM1;


### PR DESCRIPTION
Modify the order of the MARTINI energy loss routine so that it access the hydro information after it accepts a given parton.