### PR TITLE
update PYTHIA version in docker base image

### DIFF
--- a/.github/workflows/test-build-external.yaml
+++ b/.github/workflows/test-build-external.yaml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     
     container:
-      image: jetscape/base:v1.4
+      image: jetscape/base:v1.5
       options: --user root
       
     steps:

--- a/.github/workflows/test-events.yaml
+++ b/.github/workflows/test-events.yaml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     
     container:
-      image: jetscape/base:v1.4
+      image: jetscape/base:v1.5
       options: --user root
       
     steps:

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -73,11 +73,11 @@ RUN curl -SL http://hepmc.web.cern.ch/hepmc/releases/HepMC3-3.1.1.tar.gz | tar -
 && rm -r /usr/local/hepmc3-build
 ENV LD_LIBRARY_PATH="/usr/local/lib:${LD_LIBRARY_PATH}"
 
-# Install Pythia8 (8.235 is needed by SMASH, and it should be installed in a folder called pythia8235)
-RUN curl -SL http://home.thep.lu.se/~torbjorn/pythia8/pythia8235.tgz \
+# Install Pythia8 (8.303 is needed by SMASH)
+RUN curl -SL http://home.thep.lu.se/~torbjorn/pythia8/pythia8303.tgz \
 | tar -xvzC /usr/local \
-&& cd /usr/local/pythia8235 \
-&& ./configure --enable-shared --prefix=/usr/local/pythia8235 --with-hepmc3=/usr/local/HepMC3-3.1.1 \
+&& cd /usr/local/pythia8303 \
+&& ./configure --enable-shared --prefix=/usr/local --with-hepmc3=/usr/local/HepMC3-3.1.1 \
 && make -j8 \
 && make -j8 install
 
@@ -86,8 +86,8 @@ ARG username=jetscape-user
 ENV JETSCAPE_DIR="/home/${username}/JETSCAPE"
 ENV SMASH_DIR="${JETSCAPE_DIR}/external_packages/smash/smash_code"
 ENV EIGEN3_ROOT /usr/include/eigen3
-ENV PYTHIA8DIR /usr/local/pythia8235
-ENV PYTHIA8_ROOT_DIR /usr/local/pythia8235
+ENV PYTHIA8DIR /usr/local
+ENV PYTHIA8_ROOT_DIR /usr/local
 ENV PATH $PATH:$PYTHIA8DIR/bin
 
 # Build heppy (various HEP tools via python)

--- a/docker/README.md
+++ b/docker/README.md
@@ -57,12 +57,12 @@ The docker container will contain only the pre-requisite environment to build JE
 
     **macOS:**
     ```
-    docker run -it -v ~/jetscape-docker:/home/jetscape-user --name myJetscape jetscape/base:v1.4
+    docker run -it -v ~/jetscape-docker:/home/jetscape-user --name myJetscape jetscape/base:v1.5
    ```
 
     **linux:**
     ```
-    docker run -it -v ~/jetscape-docker:/home/jetscape-user --name myJetscape --user $(id -u):$(id -g) jetscape/base:v1.4
+    docker run -it -v ~/jetscape-docker:/home/jetscape-user --name myJetscape --user $(id -u):$(id -g) jetscape/base:v1.5
     ```
     
     For details on the compatibility of docker image versions with JETSCAPE versions, please see the [jetscape dockerhub](https://hub.docker.com/r/jetscape/base) page.


### PR DESCRIPTION
(needed since SMASH updated PYTHIA requirement from 8.235 --> 8.303)

After this PR is integrated to master, the automated tests will use the updated base container. 