### PR TITLE
Create different options for cmake builds

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -12,6 +12,11 @@ if(CMAKE_SOURCE_DIR STREQUAL CMAKE_BINARY_DIR)
   message(FATAL_ERROR "You don't want to configure in the source directory!")
 endif()
 
+# Default to the release build.
+if(NOT CMAKE_BUILD_TYPE)
+  set(CMAKE_BUILD_TYPE Release)
+endif()
+
 # for mac compliance
 cmake_policy(SET CMP0042 NEW)
 
@@ -80,9 +85,12 @@ endif (USE_SMASH)
 ### Compiler & Linker Flags ###
 ###############################
 message("Compiler and Linker flags ...")
-set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -g -O -fPIC -pipe -Wall -std=c++11")
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fPIC -pipe -Wall -std=c++11")
 ## can turn off some warnings
 set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-reorder -Wno-unused-variable ")
+## Then set the build type specific options. These will be automatically appended.
+set(CMAKE_CXX_FLAGS_DEBUG "-g -O0")
+set(CMAKE_CXX_FLAGS_RELEASE "-O3")
 ## can turn on debugging information
 # set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -g")
 


### PR DESCRIPTION
Defaults to a Release build, which includes full optimizations (`-O3`). Developers will probably want to use the Debug release. Can specify when running CMake with `-DCMAKE_BUILD_TYPE="Release"` (for example)

Note that this doesn't allow for arbitrarily setting the optimization level - it's either -O3 or -O0. Such a change could come later - it most likely requires someone more knowledgeable about CMake (plus, we need to move quickly for the STAT calculations)

Closes #71