### PR TITLE
change unsigned int to int in ColoredHadronization

### DIFF
--- a/src/hadronization/ColoredHadronization.cc
+++ b/src/hadronization/ColoredHadronization.cc
@@ -225,7 +225,7 @@ void ColoredHadronization::DoHadronization(
   int updcol = 1;
   while (col_instances.size() > 0) {
     int nupd = 2;
-    for (unsigned int i = event.size() - 1; i >= 0; --i) {
+    for ( int i = event.size() - 1; i >= 0; --i) {
       if (col_instances[0][0] == event[i].col()) {
         event[i].col(updcol);
         --nupd;


### PR DESCRIPTION
Minor change.
Changing the counter "i" from "unsigned int" to "int". Since the unsigned int can not hold a negative number, the counter "i" will go 2^{23}-1 if "--i" is called when i=0. 