### PR TITLE
Writer for final state partons and hadrons

### DIFF
--- a/config/jetscape_master.xml
+++ b/config/jetscape_master.xml
@@ -26,6 +26,8 @@
   <JetScapeWriterAscii> off </JetScapeWriterAscii>
   <JetScapeWriterAsciiGZ> off </JetScapeWriterAsciiGZ>
   <JetScapeWriterHepMC> off </JetScapeWriterHepMC>
+  <JetScapeWriterFinalStatePartonsAscii> off </JetScapeWriterFinalStatePartonsAscii>
+  <JetScapeWriterFinalStateHadronsAscii> off </JetScapeWriterFinalStateHadronsAscii>
 
   <!--  Random Settings. For now, just a global  seed. -->
   <!--  Note: It's each modules responsibility to adopt it -->

--- a/examples/FinalStateHadrons.cc
+++ b/examples/FinalStateHadrons.cc
@@ -2,7 +2,7 @@
  * Copyright (c) The JETSCAPE Collaboration, 2018
  *
  * Modular, task-based framework for simulating all aspects of heavy-ion collisions
- * 
+ *
  * For the list of contributors see AUTHORS.
  *
  * Report issues at https://github.com/JETSCAPE/JETSCAPE/issues
@@ -48,40 +48,83 @@ int main(int argc, char** argv)
   // //SetVerboseLevel (9 a lot of additional debug output ...)
   // //If you want to suppress it: use SetVerboseLevle(0) or max  SetVerboseLevel(9) or 10
   JetScapeLogger::Instance()->SetVerboseLevel(0);
-  
+
+  // Whether to write the new header (ie. v2), including xsec info.
+  // To enable, pass anything as the third argument to enable this option.
+  // Default: disabled.
+  bool writeHeaderV2 = false;
+  if (argc > 3) {
+    writeHeaderV2 = static_cast<bool>(argv[3]);
+    std::cout << "NOTE: Writing header v2, and final cross section and error at EOF.\n";
+  }
+
   auto reader=make_shared<JetScapeReaderAscii>(argv[1]);
   std::ofstream dist_output (argv[2]); //Format is SN, PID, E, Px, Py, Pz, Eta, Phi
   vector<shared_ptr<Hadron>> hadrons;
   int SN=0;
   while (!reader->Finished())
+  {
+    reader->Next();
+
+    // cout<<"Analyze current event: "<<reader->GetCurrentEvent()<<endl;
+
+    //dist_output<<"Event "<< reader->GetCurrentEvent()+1<<endl;
+    hadrons = reader->GetHadrons();
+    cout<<"Number of hadrons is: " << hadrons.size() << endl;
+
+    if (hadrons.size() > 0)
     {
-      reader->Next();
-      
-      // cout<<"Analyze current event: "<<reader->GetCurrentEvent()<<endl;
+      ++SN;
+      if (writeHeaderV2) {
+        // NOTE: Needs consistent "\t" between all entries to simplify parsing later.
+        dist_output << "#" << "\t"
+            << "Event\t" << SN << "\t"
+            << "weight\t" << reader->GetEventWeight() << "\t"
+            << "EPangle\t" << reader->GetEventPlaneAngle() <<"\t"
+            << "N_hadrons\t" << hadrons.size() << "\t"
+            << "|" << "\t"  // As a delimiter
+            << "N" << "\t"
+            << "pid" << "\t"
+            << "status" << "\t"
+            << "E"   << "\t"
+            << "Px"  << "\t"
+            << "Py"  << "\t"
+            << "Pz"  << "\t"
+            << "Eta" <<  "\t"
+            << "Phi" << "\n";
+      }
+      else {
+        dist_output << "#" << "\t"
+            << reader->GetEventPlaneAngle() << "\t"
+            << "Event"
+            << SN << "ID\t"
+            << hadrons.size() << "\t"
+            << "pstat-EPx"   << "\t"
+            << "Py"  << "\t"
+            << "Pz"  << "\t"
+            << "Eta" <<  "\t"<< "Phi" << "\n";
+      }
 
-      //dist_output<<"Event "<< reader->GetCurrentEvent()+1<<endl;
-      hadrons = reader->GetHadrons();
-      cout<<"Number of hadrons is: " << hadrons.size() << endl;
-
-      if(hadrons.size() > 0)
-	{
-	  SN++;
-	  dist_output << "#"<<"\t"  
-	              << reader->GetEventPlaneAngle() <<"\t"
-		      << "Event"
-		      << SN << "ID\t"
-		      << hadrons.size() << "\t"
-		      << "pstat-EPx"   << "\t"
-		      << "Py"  << "\t"
-		      << "Pz"  << "\t"
-		      << "Eta" <<  "\t"<< "Phi" << endl;
-	  
-	  for(unsigned int i=0; i<hadrons.size(); i++)
-	    {
-	      dist_output<<i<<" "<<hadrons[i].get()->pid()<<" "<<hadrons[i].get()->pstat()<<" "<< hadrons[i].get()->e() << " "<< hadrons[i].get()->px()<< " "<< hadrons[i].get()->py() << " "<< hadrons[i].get()->pz()<<  " " << hadrons[i].get()->eta() <<" "<<hadrons[i].get()->phi() <<endl;
-	    }
-	}
+      for (unsigned int i=0; i<hadrons.size(); i++)
+      {
+        dist_output << i
+            << " " << hadrons[i].get()->pid()
+            << " " << hadrons[i].get()->pstat()
+            << " " << hadrons[i].get()->e()
+            << " " << hadrons[i].get()->px()
+            << " " << hadrons[i].get()->py()
+            << " " << hadrons[i].get()->pz()
+            << " " << hadrons[i].get()->eta()
+            << " " << hadrons[i].get()->phi() << "\n";
+      }
     }
+  }
+  // Write the final cross section and error if requested by using header v2
+  if (writeHeaderV2) {
+    // NOTE: Needs consistent "\t" between all entries to simplify parsing later.
+    dist_output << "#" << "\t"
+        << "sigmaGen\t" << reader->GetSigmaGen() << "\t"
+        << "sigmaErr\t" << reader->GetSigmaErr() << "\n";
+  }
   reader->Close();
-  
 }

--- a/examples/FinalStatePartons.cc
+++ b/examples/FinalStatePartons.cc
@@ -2,7 +2,7 @@
  * Copyright (c) The JETSCAPE Collaboration, 2018
  *
  * Modular, task-based framework for simulating all aspects of heavy-ion collisions
- * 
+ *
  * For the list of contributors see AUTHORS.
  *
  * Report issues at https://github.com/JETSCAPE/JETSCAPE/issues
@@ -48,57 +48,93 @@ int main(int argc, char** argv)
   // //SetVerboseLevel (9 a lot of additional debug output ...)
   // //If you want to suppress it: use SetVerboseLevle(0) or max  SetVerboseLevel(9) or 10
   JetScapeLogger::Instance()->SetVerboseLevel(0);
-  
+
+  // Whether to write the new header (ie. v2), including xsec info.
+  // To enable, pass anything as the third argument to enable this option.
+  // Default: disabled.
+  bool writeHeaderV2 = false;
+  if (argc > 3) {
+    writeHeaderV2 = static_cast<bool>(argv[3]);
+    std::cout << "NOTE: Writing header v2, and final cross section and error at EOF.\n";
+  }
+
   auto reader=make_shared<JetScapeReaderAscii>(argv[1]);
   std::ofstream dist_output (argv[2]); //Format is SN, PID, E, Px, Py, Pz, Eta, Phi
   int SN=0, TotalPartons=0;
   while (!reader->Finished())
+  {
+    reader->Next();
+
+    // cout<<"Analyze current event: "<<reader->GetCurrentEvent()<<endl;
+    auto mShowers=reader->GetPartonShowers();
+
+    TotalPartons = 0;
+    for (int i=0; i < mShowers.size(); i++)
     {
-      
-      reader->Next();
-      
-      // cout<<"Analyze current event: "<<reader->GetCurrentEvent()<<endl;
-      auto mShowers=reader->GetPartonShowers();     
-
-      TotalPartons =0;
-      for (int i=0;i<mShowers.size();i++)
-        {
-	  TotalPartons = TotalPartons + mShowers[i]->GetFinalPartons().size();
-        }
-
-      if(TotalPartons > 0)
-	{ SN = SN + 1;
-	  dist_output << "#"<<"\t"
-		      << reader->GetEventPlaneAngle() <<"\t"
-		      << "Event"
-		      << SN << "ID\t"
-		      << TotalPartons << "\t"
-		      << "pstat-EPx"  << "\t"
-		      << "Py"  << "\t"
-		      << "Pz"  << "\t"
-		      << "Eta" <<  "\t"<< "Phi" << endl;
-	  
-	  for (int i=0;i<mShowers.size();i++)
-	    {
-	      //cout<<" Analyze parton shower: "<<i<<endl;
-	      // Let's create a file
-	      for ( int ipart = 0; ipart< mShowers[i]->GetFinalPartons().size(); ++ipart){
-		Parton p = *mShowers[i]->GetFinalPartons().at(ipart);
-		//            if(abs(p.pid())!=5) continue;
-		
-		dist_output << ipart   << "\t"
-			    << p.pid() << "\t"
-			    << p.pstat() << "\t"
-			    << p.e()   << "\t"
-			    << p.px()  << "\t" 
-			    << p.py()  << "\t" 
-			    << p.pz()  << "\t"
-			    << p.eta()<<  "\t"<< p.phi() << endl;
-	      }
-	    }
-	}
-      
+      TotalPartons = TotalPartons + mShowers[i]->GetFinalPartons().size();
     }
-  
-  reader->Close(); 
+
+    if(TotalPartons > 0)
+    {
+      ++SN;
+      if (writeHeaderV2) {
+        // NOTE: Needs consistent "\t" between all entries to simplify parsing later.
+        dist_output << "#" << "\t"
+            << "Event\t" << SN << "\t"
+            << "weight\t" << reader->GetEventWeight() << "\t"
+            << "EPangle\t" << reader->GetEventPlaneAngle() <<"\t"
+            << "N_partons\t" << TotalPartons << "\t"
+            << "|" << "\t"  // As a delimiter
+            << "N" << "\t"
+            << "pid" << "\t"
+            << "status" << "\t"
+            << "E"   << "\t"
+            << "Px"  << "\t"
+            << "Py"  << "\t"
+            << "Pz"  << "\t"
+            << "Eta" <<  "\t"
+            << "Phi" << "\n";
+      }
+      else {
+        dist_output << "#" << "\t"
+            << reader->GetEventPlaneAngle() << "\t"
+            << "Event"
+            << SN << "ID\t"
+            << TotalPartons << "\t"
+            << "pstat-EPx"  << "\t"
+            << "Py"  << "\t"
+            << "Pz"  << "\t"
+            << "Eta" <<  "\t"<< "Phi" << "\n";
+      }
+
+      for (int i=0; i < mShowers.size(); i++)
+      {
+        //cout<<" Analyze parton shower: "<<i<<endl;
+        // Let's create a file
+        for (int ipart = 0; ipart < mShowers[i]->GetFinalPartons().size(); ++ipart)
+        {
+          Parton p = *mShowers[i]->GetFinalPartons().at(ipart);
+          //            if(abs(p.pid())!=5) continue;
+
+          dist_output << ipart   << "\t"
+              << p.pid() << "\t"
+              << p.pstat() << "\t"
+              << p.e()   << "\t"
+              << p.px()  << "\t"
+              << p.py()  << "\t"
+              << p.pz()  << "\t"
+              << p.eta() <<  "\t"
+              << p.phi() << "\n";
+        }
+      }
+    }
+  }
+  // Write the final cross section and error if requested by using header v2
+  if (writeHeaderV2) {
+    // NOTE: Needs consistent "\t" between all entries to simplify parsing later.
+    dist_output << "#" << "\t"
+        << "sigmaGen\t" << reader->GetSigmaGen() << "\t"
+        << "sigmaErr\t" << reader->GetSigmaErr() << "\n";
+  }
+  reader->Close();
 }

--- a/src/framework/JetScape.cc
+++ b/src/framework/JetScape.cc
@@ -706,6 +706,8 @@ void JetScape::DetermineWritersFromXML() {
   std::string outputFilenameAscii = outputFilename;
   std::string outputFilenameAsciiGZ = outputFilename;
   std::string outputFilenameHepMC = outputFilename;
+  std::string outputFilenameFinalStatePartonsAscii = outputFilename;
+  std::string outputFilenameFinalStateHadronsAscii = outputFilename;
 
   // Check if each writer is enabled, and if so add it to the task list
   CheckForWriterFromXML("JetScapeWriterAscii",
@@ -714,6 +716,10 @@ void JetScape::DetermineWritersFromXML() {
                         outputFilenameAsciiGZ.append(".dat.gz"));
   CheckForWriterFromXML("JetScapeWriterHepMC",
                         outputFilenameHepMC.append(".hepmc"));
+  CheckForWriterFromXML("JetScapeWriterFinalStatePartonsAscii",
+                        outputFilenameFinalStatePartonsAscii.append("_final_state_partons.dat"));
+  CheckForWriterFromXML("JetScapeWriterFinalStateHadronsAscii",
+                        outputFilenameFinalStateHadronsAscii.append("_final_state_hadrons.dat"));
 
   // Check for custom writers
   tinyxml2::XMLElement *element =

--- a/src/framework/JetScapeWriterFinalStateStream.cc
+++ b/src/framework/JetScapeWriterFinalStateStream.cc
@@ -25,26 +25,20 @@ namespace Jetscape {
 // Register the modules with the base class
 template <>
 RegisterJetScapeModule<JetScapeWriterFinalStatePartonsStream<ofstream>>
-    JetScapeWriterFinalStatePartonsStream<ofstream>::regParton("CustomWriterFinalStatePartonsAscii");
+    JetScapeWriterFinalStatePartonsStream<ofstream>::regParton("JetScapeWriterFinalStatePartonsAscii");
 template <>
 RegisterJetScapeModule<JetScapeWriterFinalStateHadronsStream<ofstream>>
-    JetScapeWriterFinalStateHadronsStream<ofstream>::regHadron("CustomWriterFinalStateHadronsAscii");
+    JetScapeWriterFinalStateHadronsStream<ofstream>::regHadron("JetScapeWriterFinalStateHadronsAscii");
 template <>
 RegisterJetScapeModule<JetScapeWriterFinalStatePartonsStream<ogzstream>>
-    JetScapeWriterFinalStatePartonsStream<ogzstream>::regPartonGZ("CustomWriterFinalStatePartonsAsciiGZ");
+    JetScapeWriterFinalStatePartonsStream<ogzstream>::regPartonGZ("JetScapeWriterFinalStatePartonsAsciiGZ");
 template <>
 RegisterJetScapeModule<JetScapeWriterFinalStateHadronsStream<ogzstream>>
-    JetScapeWriterFinalStateHadronsStream<ogzstream>::regHadronGZ("CustomWriterFinalStateHadronsAsciiGZ");
+    JetScapeWriterFinalStateHadronsStream<ogzstream>::regHadronGZ("JetScapeWriterFinalStateHadronsAsciiGZ");
 
 template <class T>
 JetScapeWriterFinalStateStream<T>::JetScapeWriterFinalStateStream(string m_file_name_out) {
   SetOutputFileName(m_file_name_out);
-}
-
-template <class T>
-void JetScapeWriterFinalStateStream<T>::SetOutputFileName(string m_file_name_out) {
-  m_file_name_out.append("_final_state_" + GetName() + ".dat");
-  file_name_out = m_file_name_out;
 }
 
 template <class T> JetScapeWriterFinalStateStream<T>::~JetScapeWriterFinalStateStream() {

--- a/src/framework/JetScapeWriterFinalStateStream.cc
+++ b/src/framework/JetScapeWriterFinalStateStream.cc
@@ -1,0 +1,152 @@
+/*******************************************************************************
+ * Copyright (c) The JETSCAPE Collaboration, 2018
+ *
+ * Modular, task-based framework for simulating all aspects of heavy-ion collisions
+ *
+ * For the list of contributors see AUTHORS.
+ *
+ * Report issues at https://github.com/JETSCAPE/JETSCAPE/issues
+ *
+ * or via email to bugs.jetscape@gmail.com
+ *
+ * Distributed under the GNU General Public License 3.0 (GPLv3 or later).
+ * See COPYING for details.
+ ******************************************************************************/
+// Jetscape final state {hadrons,kartons} writer ascii class
+// Based on JetScapeWriterStream.
+// author: Raymond Ehlers <raymond.ehlers@cern.ch>, ORNL
+
+#include "JetScapeWriterFinalStateStream.h"
+#include "JetScapeLogger.h"
+#include "JetScapeXML.h"
+
+namespace Jetscape {
+
+// Register the modules with the base class
+template <>
+RegisterJetScapeModule<JetScapeWriterFinalStatePartonsStream<ofstream>>
+    JetScapeWriterFinalStatePartonsStream<ofstream>::regParton("CustomWriterFinalStatePartonsAscii");
+template <>
+RegisterJetScapeModule<JetScapeWriterFinalStateHadronsStream<ofstream>>
+    JetScapeWriterFinalStateHadronsStream<ofstream>::regHadron("CustomWriterFinalStateHadronsAscii");
+template <>
+RegisterJetScapeModule<JetScapeWriterFinalStatePartonsStream<ogzstream>>
+    JetScapeWriterFinalStatePartonsStream<ogzstream>::regPartonGZ("CustomWriterFinalStatePartonsAsciiGZ");
+template <>
+RegisterJetScapeModule<JetScapeWriterFinalStateHadronsStream<ogzstream>>
+    JetScapeWriterFinalStateHadronsStream<ogzstream>::regHadronGZ("CustomWriterFinalStateHadronsAsciiGZ");
+
+template <class T>
+JetScapeWriterFinalStateStream<T>::JetScapeWriterFinalStateStream(string m_file_name_out) {
+  SetOutputFileName(m_file_name_out);
+}
+
+template <class T>
+void JetScapeWriterFinalStateStream<T>::SetOutputFileName(string m_file_name_out) {
+  m_file_name_out.append("_final_state_" + GetName() + ".dat");
+  file_name_out = m_file_name_out;
+}
+
+template <class T> JetScapeWriterFinalStateStream<T>::~JetScapeWriterFinalStateStream() {
+  VERBOSE(8);
+  if (GetActive())
+    Close();
+}
+
+template <class T> void JetScapeWriterFinalStateStream<T>::WriteEvent() {
+  // Write the entire event all at once.
+
+  // First, write header
+  // NOTE: Needs consistent "\t" between all entries to simplify parsing later.
+  // NOTE: Could also add Npart, Ncoll, and TotalEntropy. See the original stream writer.
+  output_file << "#"
+      << "\t" << "Event\t" << GetCurrentEvent() + 1  // +1 to index the event count from 1
+      << "\t" << "weight\t" << GetHeader().GetEventWeight()
+      << "\t" << "EPangle\t" << (GetHeader().GetEventPlaneAngle() > -999 ? GetHeader().GetEventPlaneAngle() : 0)
+      << "\t" << "N_" << GetName() << "\t" << particles.size()
+      << "\t" << "|"  // As a delimiter
+      << "\t" << "N"
+      << "\t" << "pid"
+      << "\t" << "status"
+      << "\t" << "E"
+      << "\t" << "Px"
+      << "\t" << "Py"
+      << "\t" << "Pz"
+      << "\n";
+
+  // Next, write the particles. Will contain either hadrons or partons based on the derived class.
+  unsigned int ipart = 0;
+  for (const auto & p : particles) {
+    auto particle = p.get();
+    output_file << ipart
+        << " " << particle->pid()
+        << " " << particle->pstat()
+        << " " << particle->e()
+        << " " << particle->px()
+        << " " << particle->py()
+        << " " << particle->pz()
+        << "\n";
+    ++ipart;
+  }
+
+  // Cleanup to be ready for the next event.
+  particles.clear();
+}
+
+template <class T> void JetScapeWriterFinalStateStream<T>::Init() {
+  if (GetActive()) {
+    // Capitalize name
+    std::string name = GetName();
+    name[0] = toupper(name[0]);
+    JSINFO << "JetScape Final State " << name << " Stream Writer initialized with output file = "
+           << GetOutputFileName();
+    output_file.open(GetOutputFileName().c_str());
+  }
+}
+
+template <class T> void JetScapeWriterFinalStateStream<T>::Exec() {
+  // JSINFO<<"Run JetScapeWriterFinalStateStream<T>: Write event # "<<GetCurrentEvent()<<" ...";
+
+  // if (GetActive())
+  //   WriteEvent();
+}
+
+template <class T>
+void JetScapeWriterFinalStateStream<T>::Write(weak_ptr<PartonShower> ps) {
+  auto pShower = ps.lock();
+  if (!pShower)
+    return;
+
+  auto finalStatePartons = pShower->GetFinalPartons();
+
+  // Store final state partons.
+  for (const auto parton : finalStatePartons) {
+      particles.push_back(parton);
+  }
+}
+
+template <class T> void JetScapeWriterFinalStateStream<T>::Write(weak_ptr<Hadron> h) {
+  auto hh = h.lock();
+  if (hh) {
+    particles.push_back(hh);
+  }
+}
+
+template <class T> void JetScapeWriterFinalStateStream<T>::Close() {
+    // Write xsec output at the end.
+    // NOTE: Needs consistent "\t" between all entries to simplify parsing later.
+    output_file << "#" << "\t"
+        << "sigmaGen\t" << GetHeader().GetSigmaGen() << "\t"
+        << "sigmaErr\t" << GetHeader().GetSigmaErr() << "\n";
+    output_file.close();
+}
+
+template class JetScapeWriterFinalStatePartonsStream<ofstream>;
+template class JetScapeWriterFinalStateHadronsStream<ofstream>;
+
+#ifdef USE_GZIP
+template class JetScapeWriterFinalStatePartonsStream<ogzstream>;
+template class JetScapeWriterFinalStateHadronsStream<ogzstream>;
+#endif
+
+} // end namespace Jetscape

--- a/src/framework/JetScapeWriterFinalStateStream.cc
+++ b/src/framework/JetScapeWriterFinalStateStream.cc
@@ -58,14 +58,6 @@ template <class T> void JetScapeWriterFinalStateStream<T>::WriteEvent() {
       << "\t" << "weight\t" << GetHeader().GetEventWeight()
       << "\t" << "EPangle\t" << (GetHeader().GetEventPlaneAngle() > -999 ? GetHeader().GetEventPlaneAngle() : 0)
       << "\t" << "N_" << GetName() << "\t" << particles.size()
-      << "\t" << "|"  // As a delimiter
-      << "\t" << "N"
-      << "\t" << "pid"
-      << "\t" << "status"
-      << "\t" << "E"
-      << "\t" << "Px"
-      << "\t" << "Py"
-      << "\t" << "Pz"
       << "\n";
 
   // Next, write the particles. Will contain either hadrons or partons based on the derived class.
@@ -95,6 +87,20 @@ template <class T> void JetScapeWriterFinalStateStream<T>::Init() {
     JSINFO << "JetScape Final State " << name << " Stream Writer initialized with output file = "
            << GetOutputFileName();
     output_file.open(GetOutputFileName().c_str());
+    // NOTE: This header will only be printed once at the beginning on the file.
+    output_file << "#"
+        // The specifics the version number. For consistency in parsing, the string
+        // will always be "v<number>"
+        << "\t" << "JETSCAPE_FINAL_STATE\t" << "v2"
+        << "\t" << "|"  // As a delimiter
+        << "\t" << "N"
+        << "\t" << "pid"
+        << "\t" << "status"
+        << "\t" << "E"
+        << "\t" << "Px"
+        << "\t" << "Py"
+        << "\t" << "Pz"
+        << "\n";
   }
 }
 

--- a/src/framework/JetScapeWriterFinalStateStream.h
+++ b/src/framework/JetScapeWriterFinalStateStream.h
@@ -41,9 +41,6 @@ public:
   JetScapeWriterFinalStateStream<T>(string m_file_name_out);
   virtual ~JetScapeWriterFinalStateStream<T>();
 
-  // This add "_final_state_*.dat" to the given filename.
-  virtual void SetOutputFileName(string m_file_name_out);
-
   void Init();
   void Exec();
 

--- a/src/framework/JetScapeWriterFinalStateStream.h
+++ b/src/framework/JetScapeWriterFinalStateStream.h
@@ -1,0 +1,104 @@
+/*******************************************************************************
+ * Copyright (c) The JETSCAPE Collaboration, 2018
+ *
+ * Modular, task-based framework for simulating all aspects of heavy-ion collisions
+ *
+ * For the list of contributors see AUTHORS.
+ *
+ * Report issues at https://github.com/JETSCAPE/JETSCAPE/issues
+ *
+ * or via email to bugs.jetscape@gmail.com
+ *
+ * Distributed under the GNU General Public License 3.0 (GPLv3 or later).
+ * See COPYING for details.
+ ******************************************************************************/
+
+// Jetscape final state {hadrons,kartons} writer ascii class
+// Based on JetScapeWriterStream.
+// author: Raymond Ehlers <raymond.ehlers@cern.ch>, ORNL
+
+#ifndef JETSCAPEWRITERSTREAM_H
+#define JETSCAPEWRITERSTREAM_H
+
+#include <fstream>
+#include <string>
+
+#ifdef USE_GZIP
+#include "gzstream.h"
+#endif
+
+#include "JetScapeWriter.h"
+
+using std::ofstream;
+
+namespace Jetscape {
+
+template <class T>
+class JetScapeWriterFinalStateStream : public JetScapeWriter {
+
+public:
+  JetScapeWriterFinalStateStream<T>(){};
+  JetScapeWriterFinalStateStream<T>(string m_file_name_out);
+  virtual ~JetScapeWriterFinalStateStream<T>();
+
+  // This add "_final_state_*.dat" to the given filename.
+  virtual void SetOutputFileName(string m_file_name_out);
+
+  void Init();
+  void Exec();
+
+  virtual std::string GetName() { throw std::runtime_error("Don't use the base class"); }
+  bool GetStatus() { return output_file.good(); }
+  // Close is utilized to add the xsec and error.
+  void Close();
+
+  void Write(weak_ptr<PartonShower> ps);
+  void Write(weak_ptr<Hadron> h);
+  // We aren't interested in the individual partons or vertices, so skip them.
+
+  void WriteHeaderToFile() { };
+  void WriteEvent();
+
+  void Write(string s) { output_file << s << endl; }
+  // Intentionally make these no-ops since we want to fully control our output from this
+  // class. Tasks will often directly call these functions, so we need to prevent them from doing so.
+  void WriteComment(string s) { }
+  void WriteWhiteSpace(string s) { }
+
+protected:
+  T output_file; //!< Output file
+  std::vector<std::shared_ptr<JetScapeParticleBase>> particles;
+};
+
+template <class T>
+class JetScapeWriterFinalStatePartonsStream : public JetScapeWriterFinalStateStream<T> {
+  std::string GetName() { return "partons"; }
+  // Don't collect the hadrons by making it a no-op
+  void Write(weak_ptr<Hadron> h) { }
+protected:
+  // Allows the registration of the module so that it is available to be used by the Jetscape framework.
+  static RegisterJetScapeModule<JetScapeWriterFinalStatePartonsStream<ofstream>> regParton;
+  static RegisterJetScapeModule<JetScapeWriterFinalStatePartonsStream<ogzstream>> regPartonGZ;
+};
+
+template <class T>
+class JetScapeWriterFinalStateHadronsStream : public JetScapeWriterFinalStateStream<T> {
+  std::string GetName() { return "hadrons"; }
+  // Don't collect the hadrons by making it a no-op
+  void Write(weak_ptr<PartonShower> ps) { }
+protected:
+  // Allows the registration of the module so that it is available to be used by the Jetscape framework.
+  static RegisterJetScapeModule<JetScapeWriterFinalStateHadronsStream<ofstream>> regHadron;
+  static RegisterJetScapeModule<JetScapeWriterFinalStateHadronsStream<ogzstream>> regHadronGZ;
+};
+
+typedef JetScapeWriterFinalStatePartonsStream<ofstream> JetScapeWriterFinalStatePartonsAscii;
+typedef JetScapeWriterFinalStateHadronsStream<ofstream> JetScapeWriterFinalStateHadronsAscii;
+#ifdef USE_GZIP
+typedef JetScapeWriterFinalStatePartonsStream<ogzstream> JetScapeWriterFinalStatePartonsAsciiGZ;
+typedef JetScapeWriterFinalStateHadronsStream<ogzstream> JetScapeWriterFinalStateHadronsAsciiGZ;
+#endif
+
+} // end namespace Jetscape
+
+#endif // JETSCAPEWRITERSTREAM_H

--- a/src/reader/JetScapeReader.cc
+++ b/src/reader/JetScapeReader.cc
@@ -18,10 +18,14 @@
 
 namespace Jetscape {
 
-template <class T> JetScapeReader<T>::JetScapeReader() {
+template <class T> JetScapeReader<T>::JetScapeReader():
+  currentEvent{-1}
+  , sigmaGen{-1}
+  , sigmaErr{-1}
+  , eventWeight{-1}
+  , EventPlaneAngle{0.0}
+{
   VERBOSE(8);
-  currentEvent = -1;
-  EventPlaneAngle = 0.0;
 }
 
 template <class T> JetScapeReader<T>::~JetScapeReader() { VERBOSE(8); }
@@ -32,6 +36,11 @@ template <class T> void JetScapeReader<T>::Clear() {
   //pShower->clear();//pShower=nullptr; //check ...
   pShowers.clear();
   hadrons.clear();
+
+  sigmaGen = -1;
+  sigmaErr = -1;
+  eventWeight = -1;
+  EventPlaneAngle = 0.0;
 }
 
 template <class T> void JetScapeReader<T>::AddNode(string s) {
@@ -114,11 +123,33 @@ template <class T> void JetScapeReader<T>::Next() {
 
     if (strT.isCommentEntry()) {
 
+      // Cross section
+      if (line.find("sigmaGen") != std::string::npos) {
+        std::stringstream data(line);
+        std::string dummy;
+        data >> dummy >> dummy >> sigmaGen;
+        JSDEBUG << " sigma gen=" << sigmaGen;
+      }
+      // Cross section error
+      if (line.find("sigmaErr") != std::string::npos) {
+        std::stringstream data(line);
+        std::string dummy;
+        data >> dummy >> dummy >> sigmaErr;
+        JSDEBUG << " sigma err=" << sigmaErr;
+      }
+      // Event weight
+      if (line.find("weight") != std::string::npos) {
+        std::stringstream data(line);
+        std::string dummy;
+        data >> dummy >> dummy >> eventWeight;
+        JSDEBUG << " Event weight=" << eventWeight;
+      }
+      // EP angle
       if (line.find(EPAngleStr) != std::string::npos) {
         std::stringstream data(line);
         std::string dummy;
         data >> dummy >> dummy >> EventPlaneAngle;
-        JSINFO << " EventPlaneAngle=" << EventPlaneAngle;
+        JSDEBUG << " EventPlaneAngle=" << EventPlaneAngle;
       }
       continue;
     }

--- a/src/reader/JetScapeReader.h
+++ b/src/reader/JetScapeReader.h
@@ -60,6 +60,9 @@ public:
 
   vector<shared_ptr<Hadron>> GetHadrons() { return hadrons; }
   vector<fjcore::PseudoJet> GetHadronsForFastJet();
+  double GetSigmaGen() const { return sigmaGen; }
+  double GetSigmaErr() const { return sigmaErr; }
+  double GetEventWeight() const { return eventWeight; }
   double GetEventPlaneAngle() const { return EventPlaneAngle; }
 
 private:
@@ -82,6 +85,9 @@ private:
   vector<node> nodeVec;
   vector<edge> edgeVec;
   vector<shared_ptr<Hadron>> hadrons;
+  double sigmaGen;
+  double sigmaErr;
+  double eventWeight;
   double EventPlaneAngle;
 };
 


### PR DESCRIPTION
This adds a JetScape writer for final state partons and hadrons. This way, you can write final state * without having to write the full output. I performed validation with the header v2 comparing the new writer vs the FinalState* executables in the example, and the values seem to be within an absolute tolerance of 1e-3 and relative tolerance of 5e-5. I interpret this as basically our precision limit.

Also introduces a new final state hadrons and partons ascii format, known as header v2, with contains:
- additional event information
- the cross section and error stored in the same file
- more consistent spacing for parsing
- removed eta and phi to reduce storage size (since we already have the full kinematics)

A full comparison of the header v2 format is below:

# FinalStateHadrons

## Original header

Invoked with:`./FinalStateHadrons input_ascii_file.dat final_state_hadrons.dat`
```
#   0.0116446   Event1ID    236 pstat-EPx   Py  Pz  Eta Phi
0 -211 0 2.18047 0.236423 0.673826 -2.05549 -1.77929 1.23335
1 211 0 8.62818 -0.698026 0.851136 -8.55659 -2.74796 2.25768
```
(with tabs as ">" for clarity):
```
#>0.0116446>Event1ID>236>pstat-EPx>Py>Pz>Eta>Phi
```

## Header v2

Invoked with:`./FinalStateHadrons input_ascii_file.dat final_state_hadrons.dat true`
```
#   Event   1   weight  0.129547    EPangle 0.0116446   N_hadrons   236 |   N   pid status  E   Px  Py  Pz  Eta Phi
0 -211 0 2.18047 0.236423 0.673826 -2.05549 -1.77929 1.23335
1 211 0 8.62818 -0.698026 0.851136 -8.55659 -2.74796 2.25768
```
(with tabs as ">" for clarity):
```
#>Event>1>weight>0.129547>EPangle>0.0116446>N_hadrons>236>|>N>pid>status>E>Px>Py>Pz>Eta>Phi
```

# FinalStatePartons

## Original header

Invoked with:`./FinalStateHadrons input_ascii_file.dat final_state_hadrons.dat`
```
#   0.0116446   Event1ID    183 pstat-EPx   Py  Pz  Eta Phi
0   21  -1  0.332548    0.289347    -0.13353    -0.0950621  -0.294051   5.85082
1   21  1   4.45215 1.15158 -0.518765   -4.26926    -1.93227    5.85993
```
(with tabs as ">" for clarity):
```
#>0.0116446>Event1ID>183>pstat-EPx>Py>Pz>Eta>Phi
```

## Header v2

Invoked with:`./FinalStateHadrons input_ascii_file.dat final_state_hadrons.dat true`
```
#   Event   1   weight  0.129547    EPangle 0.0116446   N_partons   183 |   N   pid status  E   Px  Py  Pz  Eta Phi
0   21  -1  0.332548    0.289347    -0.13353    -0.0950621  -0.294051   5.85082
1   21  1   4.45215 1.15158 -0.518765   -4.26926    -1.93227    5.85993
```
(with tabs as ">" for clarity):
```
#>Event>1>weight>0.129547>EPangle>0.0116446>N_partons>183>|>N>pid>status>E>Px>Py>Pz>Eta>Phi
```