### PR TITLE
Use new Jetscape construction for SMASHTest

### DIFF
--- a/examples/custom_examples/CLViscTest.cc
+++ b/examples/custom_examples/CLViscTest.cc
@@ -73,13 +73,19 @@ int main(int argc, char** argv)
    
   Show();
 
-  // auto jetscape = make_shared<JetScape>("./jetscape_init.xml",10);
-  // jetscape->SetReuseHydro (true);
-  // jetscape->SetNReuseHydro (5);
+  auto jetscape = make_shared<JetScape>();
+  const char* masterXMLName = "../config/jetscape_master.xml";
+  const char* userXMLName = "../config/jetscape_user.xml";
 
-  auto jetscape = make_shared<JetScape>("./jetscape_init.xml",1);
+  jetscape->SetXMLMasterFileName(masterXMLName);
+  jetscape->SetXMLUserFileName(userXMLName);
+
+  jetscape->SetNumberOfEvents(1);
   jetscape->SetReuseHydro (false);
   jetscape->SetNReuseHydro (0);
+  // jetscape->SetNumberOfEvents(10);
+  // jetscape->SetReuseHydro (true);
+  // jetscape->SetNReuseHydro (5);
 
   // Initial conditions and hydro
   auto trento = make_shared<TrentoInitial>();

--- a/examples/custom_examples/MUSICTest.cc
+++ b/examples/custom_examples/MUSICTest.cc
@@ -73,13 +73,19 @@ int main(int argc, char** argv)
    
   Show();
 
-  // auto jetscape = make_shared<JetScape>("./jetscape_init.xml",10);
-  // jetscape->SetReuseHydro (true);
-  // jetscape->SetNReuseHydro (5);
+  auto jetscape = make_shared<JetScape>();
+  const char* masterXMLName = "../config/jetscape_master.xml";
+  const char* userXMLName = "../config/jetscape_user.xml";
 
-  auto jetscape = make_shared<JetScape>("./jetscape_init.xml",2);
+  jetscape->SetXMLMasterFileName(masterXMLName);
+  jetscape->SetXMLUserFileName(userXMLName);
+
+  jetscape->SetNumberOfEvents(2);
   jetscape->SetReuseHydro (false);
   jetscape->SetNReuseHydro (0);
+  // jetscape->SetNumberOfEvents(10);
+  // jetscape->SetReuseHydro (true);
+  // jetscape->SetNReuseHydro (5);
 
   // Initial conditions and hydro
   auto trento = make_shared<TrentoInitial>();

--- a/examples/custom_examples/SMASHTest.cc
+++ b/examples/custom_examples/SMASHTest.cc
@@ -90,13 +90,18 @@ int main(int argc, char** argv)
 
   Show();
 
-  // auto jetscape = make_shared<JetScape>("./jetscape_init.xml",10);
-  // jetscape->SetReuseHydro (true);
-  // jetscape->SetNReuseHydro (5);
+  auto jetscape = make_shared<JetScape>();
+  const char* masterXMLName = "../config/jetscape_master.xml";
+  const char* userXMLName = "../config/jetscape_user.xml";
 
-  auto jetscape = make_shared<JetScape>("./jetscape_init.xml",1);
+  jetscape->SetXMLMasterFileName(masterXMLName);
+  jetscape->SetXMLUserFileName(userXMLName);
+
+
   jetscape->SetReuseHydro (false);
   jetscape->SetNReuseHydro (0);
+  // jetscape->SetReuseHydro (true);
+  // jetscape->SetNReuseHydro (5);
 
   // Initial conditions and hydro
   auto trento = make_shared<TrentoInitial>();

--- a/examples/custom_examples/SMASHTest.cc
+++ b/examples/custom_examples/SMASHTest.cc
@@ -97,9 +97,10 @@ int main(int argc, char** argv)
   jetscape->SetXMLMasterFileName(masterXMLName);
   jetscape->SetXMLUserFileName(userXMLName);
 
-
+  jetscape->SetNumberOfEvents(1);
   jetscape->SetReuseHydro (false);
   jetscape->SetNReuseHydro (0);
+  // jetscape->SetNumberOfEvents(10);
   // jetscape->SetReuseHydro (true);
   // jetscape->SetNReuseHydro (5);
 

--- a/examples/custom_examples/TwoStagesHydro.cc
+++ b/examples/custom_examples/TwoStagesHydro.cc
@@ -79,11 +79,17 @@ int main(int argc, char** argv)
    
   Show();
 
-  auto jetscape = make_shared<JetScape>("./jetscape_init.xml", 1);
+  auto jetscape = make_shared<JetScape>();
+  const char* masterXMLName = "../config/jetscape_master.xml";
+  const char* userXMLName = "../config/jetscape_user.xml";
+
+  jetscape->SetXMLMasterFileName(masterXMLName);
+  jetscape->SetXMLUserFileName(userXMLName);
+
+  jetscape->SetNumberOfEvents(1);
   jetscape->SetReuseHydro (true);
   jetscape->SetNReuseHydro (5);
-
-  //auto jetscape = make_shared<JetScape>("./jetscape_init.xml", 2);
+  // jetscape->SetNumberOfEvents(2);
   //jetscape->SetReuseHydro (false);
   //jetscape->SetNReuseHydro (0);
 

--- a/examples/custom_examples/TwoStagesHydroFromFile.cc
+++ b/examples/custom_examples/TwoStagesHydroFromFile.cc
@@ -82,11 +82,16 @@ int main(int argc, char** argv)
    
   Show();
 
-  auto jetscape = make_shared<JetScape>("./jetscape_init.xml", 2);
+  auto jetscape = make_shared<JetScape>();
+  const char* masterXMLName = "../config/jetscape_master.xml";
+  const char* userXMLName = "../config/jetscape_user.xml";
+
+  jetscape->SetXMLMasterFileName(masterXMLName);
+  jetscape->SetXMLUserFileName(userXMLName);
+
+  jetscape->SetNumberOfEvents(2);
   jetscape->SetReuseHydro (true);
   jetscape->SetNReuseHydro (5);
-
-  //auto jetscape = make_shared<JetScape>("./jetscape_init.xml", 2);
   //jetscape->SetReuseHydro (false);
   //jetscape->SetNReuseHydro (0);
 

--- a/examples/custom_examples/freestream-milneTest.cc
+++ b/examples/custom_examples/freestream-milneTest.cc
@@ -70,13 +70,19 @@ int main(int argc, char** argv)
 
   Show();
 
-  //auto jetscape = make_shared<JetScape>("./jetscape_init.xml",10);
-  //jetscape->SetReuseHydro (true);
-  //jetscape->SetNReuseHydro (5);
+  auto jetscape = make_shared<JetScape>();
+  const char* masterXMLName = "../config/jetscape_master.xml";
+  const char* userXMLName = "../config/jetscape_user.xml";
 
-  auto jetscape = make_shared<JetScape>("./jetscape_init.xml",1);
+  jetscape->SetXMLMasterFileName(masterXMLName);
+  jetscape->SetXMLUserFileName(userXMLName);
+
+  jetscape->SetNumberOfEvents(1);
   jetscape->SetReuseHydro (false);
   jetscape->SetNReuseHydro (0);
+  // jetscape->SetNumberOfEvents(10);
+  //jetscape->SetReuseHydro (true);
+  //jetscape->SetNReuseHydro (5);
 
   auto trento = make_shared<TrentoInitial> ();
   auto freestream = make_shared<FreestreamMilneWrapper> ();

--- a/examples/custom_examples/testJetScape.cc
+++ b/examples/custom_examples/testJetScape.cc
@@ -89,7 +89,14 @@ int main(int argc, char** argv)
   // Current: Just use make_shared always (propably not the most efficient solution ...)
   
   //auto jetscape = make_shared<JetScape>("/Users/putschke/JetScape/framework_xcode/jetscape_init.xml",3);
-  auto jetscape = make_shared<JetScape>("./jetscape_init.xml",3);
+  auto jetscape = make_shared<JetScape>();
+  const char* masterXMLName = "../config/jetscape_master.xml";
+  const char* userXMLName = "../config/jetscape_user.xml";
+
+  jetscape->SetXMLMasterFileName(masterXMLName);
+  jetscape->SetXMLUserFileName(userXMLName);
+
+  jetscape->SetNumberOfEvents(3);
   // if << overloaded for classes then for example (see commented out in JetScape.h)
   //cout<<*jetscape<<endl; 
   // try to automatically create in Add()!? and to handle things behind the scene ...


### PR DESCRIPTION
It appears that the SMASHTest is not using the current `Jetscape()` constructor. This PR resolves this.

I also noted that a couple of other custom examples do the same and try to use `make_shared<JetScape>("./jetscape_init.xml",1)` with `jetscape_init.xml` not found in the repository anymore(?). If this fix is ok, I can go ahead and fix the other custom examples as well.