### PR TITLE
SMASH and Pythia update

### DIFF
--- a/.github/workflows/plot_observables.yaml
+++ b/.github/workflows/plot_observables.yaml
@@ -19,7 +19,7 @@ jobs:
     runs-on: ubuntu-latest
     
     container:
-      image: jetscape/base:v1.4
+      image: jetscape/base:stable
       options: --user root
       
     steps:

--- a/.github/workflows/test-build-external.yaml
+++ b/.github/workflows/test-build-external.yaml
@@ -16,7 +16,7 @@ jobs:
     runs-on: ubuntu-latest
     
     container:
-      image: jetscape/base:v1.4
+      image: jetscape/base:stable
       options: --user root
       
     steps:

--- a/.github/workflows/test-events.yaml
+++ b/.github/workflows/test-events.yaml
@@ -16,7 +16,7 @@ jobs:
     runs-on: ubuntu-latest
     
     container:
-      image: jetscape/base:v1.4
+      image: jetscape/base:stable
       options: --user root
       
     steps:

--- a/cmakemodules/FindSMASH.cmake
+++ b/cmakemodules/FindSMASH.cmake
@@ -9,12 +9,23 @@
 # The environment variable SMASH_DIR must be set properly to succeed, e. g.:
 # export SMASH_DIR=~/Work/SMASH/smash
 
+# At the moment a macro about the system endianness is needed from within SMASH
+include(TestBigEndian)
+TEST_BIG_ENDIAN(IS_BIG_ENDIAN)
+if(IS_BIG_ENDIAN)
+   message(STATUS "Big endian architecture detected.")
+   add_definitions("-DBIG_ENDIAN_ARCHITECTURE")
+else()
+   message(STATUS "Little endian architecture detected.")
+   add_definitions("-DLITTLE_ENDIAN_ARCHITECTURE")
+endif()
+
 message(STATUS "Looking for SMASH ...")
 
 set(SMASH_INCLUDE_DIR
-   $ENV{SMASH_DIR}/3rdparty/Cuba-4.2
+   $ENV{SMASH_DIR}/3rdparty/Cuba-4.2.1
    $ENV{SMASH_DIR}/3rdparty/einhard
-   $ENV{SMASH_DIR}/3rdparty/yaml-cpp-0.6.2/include
+   $ENV{SMASH_DIR}/3rdparty/yaml-cpp-0.7.0/include
    $ENV{SMASH_DIR}/build/src/include
    $ENV{SMASH_DIR}/src/include
 )
@@ -22,8 +33,8 @@ message(STATUS "SMASH includes found in ${SMASH_INCLUDE_DIR}")
 
 find_library(SMASH_LIBRARY NAMES smash PATHS $ENV{SMASH_DIR}/build/src)
 find_library(EINHARD_LIBRARY NAMES einhard PATHS $ENV{SMASH_DIR}/build/3rdparty/einhard)
-find_library(CPPYAML_LIBRARY NAMES yaml-cpp PATHS $ENV{SMASH_DIR}/build/3rdparty/yaml-cpp-0.6.2)
-find_library(INTEGRATION_LIBRARY NAMES cuhre PATHS $ENV{SMASH_DIR}/build/3rdparty/Cuba-4.2/src/cuhre)
+find_library(CPPYAML_LIBRARY NAMES yaml-cpp PATHS $ENV{SMASH_DIR}/build/3rdparty/yaml-cpp-0.7.0)
+find_library(INTEGRATION_LIBRARY NAMES cuhre PATHS $ENV{SMASH_DIR}/build/3rdparty/Cuba-4.2.1/src/cuhre)
 set(SMASH_LIBRARIES ${EINHARD_LIBRARY} ${CPPYAML_LIBRARY} ${SMASH_PYTHIA_LIBRARY} ${SMASH_LIBRARY} ${INTEGRATION_LIBRARY})
 
 message(STATUS "SMASH libraries: ${SMASH_LIBRARIES}")

--- a/docker/Dockerfile.base
+++ b/docker/Dockerfile.base
@@ -73,11 +73,12 @@ RUN curl -SL http://hepmc.web.cern.ch/hepmc/releases/HepMC3-3.1.1.tar.gz | tar -
 && rm -r /usr/local/hepmc3-build
 ENV LD_LIBRARY_PATH="/usr/local/lib:${LD_LIBRARY_PATH}"
 
-# Install Pythia8 (8.235 is needed by SMASH, and it should be installed in a folder called pythia8235)
-RUN curl -SL http://home.thep.lu.se/~torbjorn/pythia8/pythia8235.tgz \
+# Install Pythia8 (that is needed by SMASH)
+ARG pythiaV="8307"
+RUN curl -SLk http://pythia.org/download/pythia83/pythia${pythiaV}.tgz \
 | tar -xvzC /usr/local \
-&& cd /usr/local/pythia8235 \
-&& ./configure --enable-shared --prefix=/usr/local/pythia8235 --with-hepmc3=/usr/local/HepMC3-3.1.1 \
+&& cd /usr/local/pythia${pythiaV} \
+&& ./configure --enable-shared --prefix=/usr/local/ --with-hepmc3=/usr/local/HepMC3-3.1.1 \
 && make -j8 \
 && make -j8 install
 
@@ -86,8 +87,8 @@ ARG username=jetscape-user
 ENV JETSCAPE_DIR="/home/${username}/JETSCAPE"
 ENV SMASH_DIR="${JETSCAPE_DIR}/external_packages/smash/smash_code"
 ENV EIGEN3_ROOT /usr/include/eigen3
-ENV PYTHIA8DIR /usr/local/pythia8235
-ENV PYTHIA8_ROOT_DIR /usr/local/pythia8235
+ENV PYTHIA8DIR /usr/local/
+ENV PYTHIA8_ROOT_DIR /usr/local/
 ENV PATH $PATH:$PYTHIA8DIR/bin
 
 # Build heppy (various HEP tools via python)
@@ -99,7 +100,7 @@ RUN git clone https://github.com/matplo/heppy.git \
 && ./cpptools/build.sh
 
 # Install environment modules
-RUN curl -SL https://sourceforge.net/projects/modules/files/Modules/modules-4.5.1/modules-4.5.1.tar.gz \
+RUN curl -SLk https://sourceforge.net/projects/modules/files/Modules/modules-4.5.1/modules-4.5.1.tar.gz \
 | tar -xvzC /usr/local \
 && cd /usr/local/modules-4.5.1 \
 && ./configure --prefix=/usr/local --modulefilesdir=/heppy/modules \

--- a/docker/Dockerfile.deploy
+++ b/docker/Dockerfile.deploy
@@ -1,4 +1,4 @@
-FROM jetscape/base:v1.4
+FROM jetscape/base:stable
 
 COPY --chown=jetscape-user:jetscape-user JETSCAPE-DOCKER /home/jetscape-user/JETSCAPE
 RUN cd JETSCAPE/external_packages && \

--- a/docker/README.md
+++ b/docker/README.md
@@ -1,19 +1,19 @@
 ## Using JETSCAPE via Docker
 
-Docker is a software tool that allows one to deploy an application in a portable environment. 
+Docker is a software tool that allows one to deploy an application in a portable environment.
 A docker "image" can be created for the application, allowing any user to run a docker "container" from this image.
 We have prepared a docker image for the JETSCAPE environment, which allows you to use JETSCAPE on macOS or linux without
-installing a long list of pre-reqs or worrying about interference with software you already have installed. Step-by-step instructions are provided below. 
+installing a long list of pre-reqs or worrying about interference with software you already have installed. Step-by-step instructions are provided below.
 
-For those unfamiliar with Docker: To illustrate what this will look like, consider the following standard workflow. 
-In a terminal on your machine (call it Terminal 1), you will clone JETSCAPE &mdash; this terminal is on your "host" machine &mdash; 
-just a standard, typical terminal. In another terminal (call it Terminal 2), you will invoke a command that runs a pre-defined docker container. 
-Terminal 2 then lives entirely inside this docker container, completely separated from your host machine. It can *only* access the files that 
-are inside that pre-defined docker container &mdash; and not any of the files on your host machine &mdash; unless we explicitly share a 
-folder between them. The standard workflow that we envision is the following: You will share the folder containing JETSCAPE between the 
-host machine and the docker container. Then, anytime you want to **build** or **run** JETSCAPE, you *must* do it inside the docker container. 
-But anytime you want to edit text files (e.g. to construct your own configuration file), or analyze your output files, you can do this from your 
-host machine (which we recommend). Simple as that: Depending which action you want to do, perform it either on the host machine, 
+For those unfamiliar with Docker: To illustrate what this will look like, consider the following standard workflow.
+In a terminal on your machine (call it Terminal 1), you will clone JETSCAPE &mdash; this terminal is on your "host" machine &mdash;
+just a standard, typical terminal. In another terminal (call it Terminal 2), you will invoke a command that runs a pre-defined docker container.
+Terminal 2 then lives entirely inside this docker container, completely separated from your host machine. It can *only* access the files that
+are inside that pre-defined docker container &mdash; and not any of the files on your host machine &mdash; unless we explicitly share a
+folder between them. The standard workflow that we envision is the following: You will share the folder containing JETSCAPE between the
+host machine and the docker container. Then, anytime you want to **build** or **run** JETSCAPE, you *must* do it inside the docker container.
+But anytime you want to edit text files (e.g. to construct your own configuration file), or analyze your output files, you can do this from your
+host machine (which we recommend). Simple as that: Depending which action you want to do, perform it either on the host machine,
 or in the docker container, as appropriate &mdash; otherwise it will not work.
 
 ### Step 1: Install Docker
@@ -21,69 +21,69 @@ or in the docker container, as appropriate &mdash; otherwise it will not work.
 #### macOS
 
 1. Install Docker Desktop for Mac: https://docs.docker.com/docker-for-mac/install/
-2. Open Docker, go to Preferences --> Advanced and 
+2. Open Docker, go to Preferences --> Advanced and
     - (i) Set CPUs to max that your computer has (`sysctl -n hw.ncpu`),
     - (ii) Set memory to what you are willing to give Docker.
 
 #### linux
 
 1. Install Docker: https://docs.docker.com/install/
-2. Allow your user to run docker (requires admin privileges): 
+2. Allow your user to run docker (requires admin privileges):
     ```
     sudo groupadd docker
     sudo usermod -aG docker $USER
     ```
     Log out and log back in.
-    
+
 For **Windows**, please follow the analogous instructions: https://docs.docker.com/install/
 
 Please note that if you have an older OS, you may need to download an older version of docker.
 
 ### Step 2: Run JETSCAPE
 
-The docker container will contain only the pre-requisite environment to build JETSCAPE, but will not actually contain JETSCAPE itself. Rather, we will create a directory on our own machine with the JETSCAPE code, and share this directory with the docker container. This will allow us to build and run JETSCAPE inside the docker container, but to easily edit macros and access the output files on our own machine. 
+The docker container will contain only the pre-requisite environment to build JETSCAPE, but will not actually contain JETSCAPE itself. Rather, we will create a directory on our own machine with the JETSCAPE code, and share this directory with the docker container. This will allow us to build and run JETSCAPE inside the docker container, but to easily edit macros and access the output files on our own machine.
 
-1. Make a directory on your machine (which will be shared with the docker container), and clone JETSCAPE into it. 
+1. Make a directory on your machine (which will be shared with the docker container), and clone JETSCAPE into it.
     ```
     mkdir ~/jetscape-docker
     cd ~/jetscape-docker
     git clone https://github.com/JETSCAPE/JETSCAPE.git
     ```
-    
+
     In what follows we assume such a directory at `~/jetscape-docker`. You may decide to name your directory something else,
     but if so **please be careful to substitute your directory name appropriately in the instructions below**.
 
-2. Create and start a docker container that contains all of the JETSCAPE pre-reqs: 
+2. Create and start a docker container that contains all of the JETSCAPE pre-reqs:
 
     **macOS:**
     ```
-    docker run -it -v ~/jetscape-docker:/home/jetscape-user --name myJetscape jetscape/base:v1.4
+    docker run -it -v ~/jetscape-docker:/home/jetscape-user --name myJetscape jetscape/base:stable
    ```
 
     **linux:**
     ```
-    docker run -it -v ~/jetscape-docker:/home/jetscape-user --name myJetscape --user $(id -u):$(id -g) jetscape/base:v1.4
+    docker run -it -v ~/jetscape-docker:/home/jetscape-user --name myJetscape --user $(id -u):$(id -g) jetscape/base:stable
     ```
-    
+
     For details on the compatibility of docker image versions with JETSCAPE versions, please see the [jetscape dockerhub](https://hub.docker.com/r/jetscape/base) page.
 
     This is what the `docker run` command does:
-    - `docker run` creates and starts a new docker container from a pre-defined image jetscape/base:v1.3, which will be downloaded if necessary.
+    - `docker run` creates and starts a new docker container from a pre-defined image jetscape/base:stable, which will be downloaded if necessary.
     - `-it` runs the container with an interactive shell.
     - `-v` mounts a shared folder between your machine (at ~/jetscape-docker) and the container (at /home/jetscape-user), through which you can transfer files to and from the container. You can edit the location of the folder on your machine as you like.
     - `--name` (optional) sets a name for your container, for convenience. Edit it as you like.
     - `--user $(id -u):$(id -g)` (only needed on linux) runs the docker container with the same user permissions as the current user on your machine (since docker uses the same kernel as your host machine, the UIDs are shared). Note that the prompt will display "I have no name!", which is normal.
-    
-    Note that on linux, you may want to add the option `--memory <limit>` to limit the amount of memory that docker is allowed to 
+
+    Note that on linux, you may want to add the option `--memory <limit>` to limit the amount of memory that docker is allowed to
     consume (by default, the available memory and CPUs are not limited on linux, since it is not run in a VM as in macOS).
-    
+
     Some useful commands:
     - To see the containers you have running, and get their ID: `docker container ls` (`-a` to see also stopped containers)
     - To stop the container: `docker stop <container>` or `exit`
     - To re-start the container: `docker start -ai <container>`
-    - To put a running container into detatched mode: `Ctrl-p Ctrl-q`, and to re-attach: `docker attach <container>` 
+    - To put a running container into detatched mode: `Ctrl-p Ctrl-q`, and to re-attach: `docker attach <container>`
     - To delete a container: `docker container rm <container>`
-    
+
     For example to exit and re-enter the docker container:
     ```
     [From inside the container]
@@ -112,7 +112,7 @@ From **inside** the docker container, we can now build JETSCAPE:
     make -j4     # Builds using 4 cores; adapt as appropriate
     ```
 
-*That's it!* You are now inside the docker container, with JETSCAPE and all of its prequisites installed. 
-You can run JETSCAPE executables or re-compile code. Moreover, since we set up the jetscape-docker folder to be shared between your 
-host and the docker container, you can do text-editing etc. on your host machine, and then immediately build JETSCAPE in the docker container. 
+*That's it!* You are now inside the docker container, with JETSCAPE and all of its prequisites installed.
+You can run JETSCAPE executables or re-compile code. Moreover, since we set up the jetscape-docker folder to be shared between your
+host and the docker container, you can do text-editing etc. on your host machine, and then immediately build JETSCAPE in the docker container.
 Output files are also immediately accessible on your host machine if desired.

--- a/external_packages/get_smash.sh
+++ b/external_packages/get_smash.sh
@@ -14,7 +14,7 @@
 ##############################################################################
 
 # 1) Download the SMASH code
-git clone --depth=1 https://github.com/smash-transport/smash.git --branch SMASH-1.8.1 smash/smash_code
+git clone --depth=1 https://github.com/smash-transport/smash.git --branch SMASH-2.2 smash/smash_code
 
 # 2) Compile SMASH
 cd smash/smash_code

--- a/src/afterburner/SmashWrapper.h
+++ b/src/afterburner/SmashWrapper.h
@@ -65,6 +65,7 @@ private:
 class SmashWrapper : public Afterburner {
 private:
   bool only_final_decays_ = false;
+  double end_time_ = -1.0;
   shared_ptr<smash::Experiment<AfterburnerModus>> smash_experiment_;
 
   // Allows the registration of the module so that it is available to be used by the Jetscape framework.


### PR DESCRIPTION
This PR bumps the versions of SMASH and Pythia to their latest versions (SMASH-2.2 and Pythia 8.307). It is required that Pythia is updated together with SMASH, since SMASH-2.2 requires Pythia 8.307.

Physics-wise no changes are expected by those updates. Some minor modifications are required for the SMASH wrapper, since some SMASH functions changed. This update includes new SMASH features however like the SMASH HepMC output.

On opening this PR is not supposed to pass the test as a new docker container including the new Pythia version is required, which is not available yet. Even though, if I see it correctly, SMASH compilation is not tested at the moment with the build test. Should we change this?

Also the test using an exakt output comparison will need to be updated as a new Pythia version changes the output (statistically).

### Things left to do here:

- [ ] Push the new docker
- [ ] Update the tests and their output that is compared to, which should make the tests pass in the end
- [ ] As the event counting is now done internally in SMASH I want to see that this is still done correctly output to the JETSCAPE outputs.


Closes #81 (and #102).