### PR TITLE
Fix a segfault with the latest version of MUSIC

### DIFF
--- a/examples/test_music_files/music_input
+++ b/examples/test_music_files/music_input
@@ -86,7 +86,7 @@ Grid_size_in_y 200            # number of the grid points in y direction
 Grid_size_in_x 200            # number of the grid points in x direction
 #
 #
-EOS_to_use 7                  # type of the equation of state
+EOS_to_use 9                  # type of the equation of state
                               # 0: ideal gas
                               # 1: EOS-Q from azhydro
                               # 2: lattice EOS s95p-v1 


### PR DESCRIPTION
Change the default EoS to 9 (hotQCD EoS) for MUSIC.