### PR TITLE
Release candidate

### DIFF
--- a/test/pp/config/jetscape_user_PP19_weighted.xml
+++ b/test/pp/config/jetscape_user_PP19_weighted.xml
@@ -2,7 +2,7 @@
 
 <jetscape>
   
-  <nEvents> 10000 </nEvents>
+  <nEvents> 40000 </nEvents>
   
   <outputFilename>test_out</outputFilename>
   <JetScapeWriterFinalStateHadronsAscii> on </JetScapeWriterFinalStateHadronsAscii>


### PR DESCRIPTION
Hi @latessa @stdnmr 

This should fix the pre/post plotting in the automated plotting script. I also increased the number of test events a bit to try to get more meaningful plots.

If we implement a change to main that breaks the "exact" test (e.g. updating PYTHIA versions), we should then update the reference test file `JETSCAPE/test/plot/output/latest/test_out_histograms.root`, which can be generated by `JETSCAPE/test/generate_plots.sh`. This is in addition to the output files for the "exact" test in `JETSCAPE/test/pp/output/latest`.