### PR TITLE
warns when XML user element is not in XML main

### DIFF
--- a/.github/workflows/test-build-external.yaml
+++ b/.github/workflows/test-build-external.yaml
@@ -7,12 +7,14 @@ on:
       - release-candidate
       - JETSCAPE-3.5.1-RC
       - latessa/generalizedTests
+      - latessa/unknownUserXMLTagWarn
   push:
     branches:
       - main
       - release-candidate
       - JETSCAPE-3.5.1-RC
       - latessa/generalizedTests
+      - latessa/unknownUserXMLTagWarn
 
 env:
   REPO_NAME: ${{ github.event.repository.name }}

--- a/.github/workflows/test-events-PbPb.yaml
+++ b/.github/workflows/test-events-PbPb.yaml
@@ -7,12 +7,14 @@ on:
       - release-candidate
       - JETSCAPE-3.5.1-RC
       - latessa/generalizedTests
+      - latessa/unknownUserXMLTagWarn
   push:
     branches:
       - main
       - release-candidate
       - JETSCAPE-3.5.1-RC
       - latessa/generalizedTests
+      - latessa/unknownUserXMLTagWarn
 
 env:
   REPO_NAME: ${{ github.event.repository.name }}

--- a/.github/workflows/test-events-pp.yaml
+++ b/.github/workflows/test-events-pp.yaml
@@ -7,12 +7,14 @@ on:
       - release-candidate
       - JETSCAPE-3.5.1-RC
       - latessa/generalizedTests
+      - latessa/unknownUserXMLTagWarn
   push:
     branches:
       - main
       - release-candidate
       - JETSCAPE-3.5.1-RC
       - latessa/generalizedTests
+      - latessa/unknownUserXMLTagWarn
 
 env:
   REPO_NAME: ${{ github.event.repository.name }}

--- a/src/framework/JetScape.h
+++ b/src/framework/JetScape.h
@@ -76,6 +76,9 @@ public:
   inline unsigned int GetNReuseHydro() const { return n_reuse_hydro_; }
 
 protected:
+  void CompareElementsFromXML();
+  void recurseToBuild(std::vector<std::string> &elems, tinyxml2::XMLElement *mElement);
+  void recurseToSearch(std::vector<std::string> &elems, tinyxml2::XMLElement *uElement);
   void ReadGeneralParametersFromXML();
   void DetermineTaskListFromXML();
   void DetermineWritersFromXML();


### PR DESCRIPTION
checks the XML user file against a list of tag names generated from the XML main file and warns if a tag exists in the XML user file that is not in XML main.  The generated warning message is to help protect against possible XML tag typos in a user's XML file.