### PR TITLE
Fixed typo in Martini interpolation

### DIFF
--- a/src/jet/Martini.cc
+++ b/src/jet/Martini.cc
@@ -1640,7 +1640,7 @@ RateElastic Martini::getRateElasTotal(double pRest, double T) {
     d[1][5] = 2.5391647730624003;
   }
 
-  rateLower = T * (d[1][0] + d[0][1] / pow(u, 4.) - d[0][2] / pow(u, 3.) -
+  rateLower = T * (d[0][0] + d[0][1] / pow(u, 4.) - d[0][2] / pow(u, 3.) -
                    d[0][3] / pow(u, 2.) + d[0][4] / pow(u, 1.5) - d[0][5] / u);
   rateUpper = T * (d[1][0] + d[1][1] / pow(u, 4.) - d[1][2] / pow(u, 3.) -
                    d[1][3] / pow(u, 2.) + d[1][4] / pow(u, 1.5) - d[1][5] / u);


### PR DESCRIPTION
Fixed the typo found by @ShuzheShi in "src/jet/MARTINI.cc".

Line1643 shall read
`rateLower = T * (d[0][0] + ...`
rather than
`rateLower = T * (d[1][0] + ...`

https://github.com/JETSCAPE/JETSCAPE/pull/134