### PR TITLE
Setup massless light quarks in constructor

### DIFF
--- a/src/framework/JetScapeParticles.cc
+++ b/src/framework/JetScapeParticles.cc
@@ -77,7 +77,11 @@ JetScapeParticleBase::JetScapeParticleBase(int label, int id, int stat,
   init_jet_v();
 
   assert(InternalHelperPythia.particleData.isParticle(id));
-  set_restmass(InternalHelperPythia.particleData.m0(id));
+  if ((std::abs(pid()) == 1) || (std::abs(pid()) == 2) || (std::abs(pid()) == 3)) {
+        set_restmass(0.0);
+  } else {
+        set_restmass(InternalHelperPythia.particleData.m0(id));
+  }
 
   reset_momentum(p);
   x_in_ = x;
@@ -349,13 +353,8 @@ const double Parton::t() {
   //  double t_parton = PseudoJet::m2()  - restmass()*restmass() ;
 
   double t_parton = 0.0;
-
-  if ((std::abs(pid()) == 4) || (std::abs(pid()) == 5)) {
-    t_parton = e() * e() - px() * px() - py() * py() - pz() * pz() -
-               restmass() * restmass();
-  } else {
-    t_parton = e() * e() - px() * px() - py() * py() - pz() * pz();
-  }
+  t_parton = e() * e() - px() * px() - py() * py() - pz() * pz() -
+             restmass() * restmass();
   if (t_parton < 0.0) {
     // JSWARN << " Virtuality is negative, MATTER cannot handle these particles " << " t = " << t_parton;
     // JSWARN << " pid = "<< pid() << " E = " << e() << " px = " << px() << " py = " << py() << " pz = " << pz() ;


### PR DESCRIPTION
This is a pull request to fix this issue, [#77](https://github.com/JETSCAPE/X-SCAPE-COMP/issues/77).
Instead of checking for light quarks in `set_t` and `t`, I set the light quark masses to 0 in the constructor. 
I'm not sure if this is the right way to do it, we can discuss if there is a better way.  