### PR TITLE
Prompt photon duplication issue fixed in medium shower

### DIFF
--- a/src/hadronization/ColorlessHadronization.cc
+++ b/src/hadronization/ColorlessHadronization.cc
@@ -162,6 +162,9 @@ void ColorlessHadronization::DoHadronization(
           if (shower_in[ishower][ipart].pstat() == 0) {
             pIn.push_back(make_shared<Parton>(shower_in[ishower][ipart]));
           }
+          if (shower_in[ishower][ipart].pstat() == 22) {
+            pIn.push_back(make_shared<Parton>(shower_in[ishower][ipart])); //Allow photons with status code 22 to pass through Colorless hadronization.
+          }
         }
         if (take_recoil && shower_in[ishower][ipart].pstat() == -1 &&
             want_pos == 0) {

--- a/src/jet/LBT.cc
+++ b/src/jet/LBT.cc
@@ -184,7 +184,10 @@ void LBT::DoEnergyLoss(double deltaT, double time, double Q2,
     // Reject photons
 
     if (pIn[i].pid() == photonid) {
-      pOut.push_back(pIn[i]);
+      if(pIn[i].pstat() != 22) {
+	      pIn[i].set_stat(22); //Add status code 22 for photons that pass through LBT if it is already not assigned by one of the other JEL modules.
+              pOut.push_back(pIn[i]);
+      }
       return;
     }
 

--- a/src/jet/Matter.cc
+++ b/src/jet/Matter.cc
@@ -273,11 +273,14 @@ void Matter::DoEnergyLoss(double deltaT, double time, double Q2,
 
     // Reject photons
     if (pIn[i].pid() == photonid) {
-      VERBOSE(1) << BOLDYELLOW
-                 << " A photon was RECEIVED with px = " << pIn[i].px()
-                 << " from framework and sent back ";
+      if(pIn[i].pstat() != 22) {
+            pIn[i].set_stat(22);
+      	    VERBOSE(1) << BOLDYELLOW
+                       << " A photon was RECEIVED with px = " << pIn[i].px()
+                       << " from framework and sent back ";
 
-      pOut.push_back(pIn[i]);
+            pOut.push_back(pIn[i]);
+      }
       return;
     }
 


### PR DESCRIPTION
Add status code 22 for photons that pass through MATTER or LBT if it is already not assigned by one of the other JEL modules. Allow photons with status code 22 to pass through Colorless hadronization.