### PR TITLE
Fix rapidities in pythia IS modules and make constants consistent

### DIFF
--- a/src/framework/JetScapeConstants.h
+++ b/src/framework/JetScapeConstants.h
@@ -2,7 +2,7 @@
  * Copyright (c) The JETSCAPE Collaboration, 2018
  *
  * Modular, task-based framework for simulating all aspects of heavy-ion collisions
- * 
+ *
  * For the list of contributors see AUTHORS.
  *
  * Report issues at https://github.com/JETSCAPE/JETSCAPE/issues
@@ -34,10 +34,9 @@ static double Nc = 3.0;
 static double Lambda_QCD = 0.2;
 // 0.4 is the value chosen in JETSET
 
-static double fmToGeVinv = 5.0;
-/// < should be 1/0.197, but 5 helps in debugging.
-
 static const double hbarC = 0.197327053;
+
+static const double fmToGeVinv = 1.0 / hbarC;
 
 static double zeta3 = 1.20206;
 

--- a/src/initialstate/PGun.cc
+++ b/src/initialstate/PGun.cc
@@ -16,7 +16,6 @@
 
 #include "PGun.h"
 #include "JetScapeParticles.h"
-#include "JetScapeConstants.h"
 #include "Pythia8/Pythia.h"
 
 using namespace Jetscape;

--- a/src/initialstate/PGun.cc
+++ b/src/initialstate/PGun.cc
@@ -94,7 +94,7 @@ void PGun::Exec() {
 
   double p_abs = std::sqrt(pT*pT + p[3]*p[3]);
   if(std::abs(p_abs - p[3]) > rounding_error){
-    pseudorapidity = std::log((p_abs + p[3]) / (p_abs - p[3]));
+    pseudorapidity = 0.5 * std::log((p_abs + p[3]) / (p_abs - p[3]));
   } else {
     JSWARN << "Particle in PGun has infinite pseudorapidity.";
   }

--- a/src/initialstate/PGun.cc
+++ b/src/initialstate/PGun.cc
@@ -2,7 +2,7 @@
  * Copyright (c) The JETSCAPE Collaboration, 2018
  *
  * Modular, task-based framework for simulating all aspects of heavy-ion collisions
- * 
+ *
  * For the list of contributors see AUTHORS.
  *
  * Report issues at https://github.com/JETSCAPE/JETSCAPE/issues
@@ -16,6 +16,7 @@
 
 #include "PGun.h"
 #include "JetScapeParticles.h"
+#include "JetScapeConstants.h"
 #include "Pythia8/Pythia.h"
 
 using namespace Jetscape;
@@ -58,7 +59,7 @@ void PGun::Exec() {
 
   double p[4], xLoc[4];
 
-  double pT, rapidity, phi;
+  double pT, rapidity, phi, pseudorapidity;
   double eta_cut = 1.0;
   double tempRand;
   const double maxN = 1.0 * RAND_MAX;
@@ -91,6 +92,13 @@ void PGun::Exec() {
   p[3] = sqrt(pT * pT + mass * mass) * sinh(rapidity);
   p[0] = sqrt(pT * pT + mass * mass) * cosh(rapidity);
 
+  double p_abs = std::sqrt(pT*pT + p[3]*p[3]);
+  if(std::abs(p_abs - p[3]) > rounding_error){
+    pseudorapidity = std::log((p_abs + p[3]) / (p_abs - p[3]));
+  } else {
+    JSWARN << "Particle in PGun has infinite pseudorapidity.";
+  }
+
   // Roll for a starting point
   // See: https://stackoverflow.com/questions/15039688/random-generator-from-vector-with-probability-distribution-in-c
   for (int i = 0; i <= 3; i++) {
@@ -111,9 +119,9 @@ void PGun::Exec() {
   xLoc[2] = 0.0;
 
   if (flag_useHybridHad != 1) {
-    AddParton(make_shared<Parton>(0, parID, 0, pT, rapidity, phi, p[0], xLoc));
+    AddParton(make_shared<Parton>(0, parID, 0, pT, pseudorapidity, phi, p[0], xLoc));
   } else {
-    auto ptn = make_shared<Parton>(0, parID, 0, pT, rapidity, phi, p[0], xLoc);
+    auto ptn = make_shared<Parton>(0, parID, 0, pT, pseudorapidity, phi, p[0], xLoc);
     ptn->set_color((parID > 0) ? 100 : 0);
     ptn->set_anti_color(((parID > 0) || (parID == 21)) ? 0 : 101);
     ptn->set_max_color(102);

--- a/src/initialstate/PythiaGun.cc
+++ b/src/initialstate/PythiaGun.cc
@@ -2,7 +2,7 @@
  * Copyright (c) The JETSCAPE Collaboration, 2018
  *
  * Modular, task-based framework for simulating all aspects of heavy-ion collisions
- * 
+ *
  * For the list of contributors see AUTHORS.
  *
  * Report issues at https://github.com/JETSCAPE/JETSCAPE/issues
@@ -146,7 +146,7 @@ void PythiaGun::InitTask() {
     std::ofstream sigma_printer;
     sigma_printer.open(printer, std::ios::trunc);
 
-    
+
 }
 
 void PythiaGun::Exec() {
@@ -172,10 +172,10 @@ void PythiaGun::Exec() {
       if (!printer.empty()){
             std::ofstream sigma_printer;
             sigma_printer.open(printer, std::ios::out | std::ios::app);
-            
+
             sigma_printer << "sigma = " << GetSigmaGen() << " Err =  " << GetSigmaErr() << endl ;
             //sigma_printer.close();
-      
+
 //      JSINFO << BOLDYELLOW << " sigma = " << GetSigmaGen() << " sigma err = " << GetSigmaErr() << " printer = " << printer << " is " << sigma_printer.is_open() ;
     };
 
@@ -268,7 +268,7 @@ void PythiaGun::Exec() {
                << " at x=" << xLoc[1] << ", y=" << xLoc[2] << ", z=" << xLoc[3];
 
     VERBOSE(7) << "Adding particle with pid = " << particle.id()
-               << ", pT = " << particle.pT() << ", y = " << particle.y()
+               << ", pT = " << particle.pT() << ", eta = " << particle.eta()
                << ", phi = " << particle.phi() << ", e = " << particle.e();
 
     VERBOSE(7) << " at x=" << xLoc[1] << ", y=" << xLoc[2] << ", z=" << xLoc[3];
@@ -277,12 +277,13 @@ void PythiaGun::Exec() {
     // {
     if (flag_useHybridHad != 1) {
       AddParton(make_shared<Parton>(0, particle.id(), 0, particle.pT(),
-                                    particle.y(), particle.phi(), particle.e(),
-                                    xLoc));
+                                    particle.eta(), particle.phi(),
+                                    particle.e(), xLoc));
     } else {
       auto ptn =
-          make_shared<Parton>(0, particle.id(), 0, particle.pT(), particle.y(),
-                              particle.phi(), particle.e(), xLoc);
+          make_shared<Parton>(0, particle.id(), 0, particle.pT(),
+                              particle.eta(),particle.phi(),
+                              particle.e(), xLoc);
       ptn->set_color(particle.col());
       ptn->set_anti_color(particle.acol());
       ptn->set_max_color(1000 * (np + 1));


### PR DESCRIPTION
This PR closes #158 and closes #159. It introduces a consistent definition of hbarC and its inverse. In the pythia initial state modules, the pseudorapidity is used consistently.