### PR TITLE
Allow JETSCAPE to control the amount of screen output in MUSIC and ISS

### DIFF
--- a/external_packages/get_iSS.sh
+++ b/external_packages/get_iSS.sh
@@ -14,5 +14,5 @@
 ##############################################################################
 
 # download the code package
-git clone --depth=1 https://github.com/chunshen1987/iSS iSS
+git clone --depth=1 https://github.com/chunshen1987/iSS -b JETSCAPE iSS
 

--- a/src/hadronization/iSpectraSamplerWrapper.cc
+++ b/src/hadronization/iSpectraSamplerWrapper.cc
@@ -64,12 +64,16 @@ void iSpectraSamplerWrapper::InitTask() {
   iSpectraSampler_ptr_->paraRdr_ptr->readFromFile(input_file);
 
   // overwrite some parameters
+  int echoLevel = GetXMLElementInt({"vlevel"});
+  iSpectraSampler_ptr_->paraRdr_ptr->setVal("JSechoLevel", echoLevel);
+
   iSpectraSampler_ptr_->paraRdr_ptr->setVal("hydro_mode", hydro_mode);
   iSpectraSampler_ptr_->paraRdr_ptr->setVal("afterburner_type",
                                             afterburner_type);
   iSpectraSampler_ptr_->paraRdr_ptr->setVal("output_samples_into_files", 0);
   iSpectraSampler_ptr_->paraRdr_ptr->setVal("use_OSCAR_format", 0);
   iSpectraSampler_ptr_->paraRdr_ptr->setVal("use_gzip_format", 0);
+  iSpectraSampler_ptr_->paraRdr_ptr->setVal("use_binary_format", 0);
   iSpectraSampler_ptr_->paraRdr_ptr->setVal("store_samples_in_memory", 1);
   iSpectraSampler_ptr_->paraRdr_ptr->setVal("number_of_repeated_sampling",
                                             number_of_repeated_sampling);
@@ -92,7 +96,7 @@ void iSpectraSamplerWrapper::InitTask() {
   iSpectraSampler_ptr_->paraRdr_ptr->setVal("f0_is_not_small", 1);
 
   iSpectraSampler_ptr_->paraRdr_ptr->setVal("calculate_vn", 0);
-  iSpectraSampler_ptr_->paraRdr_ptr->setVal("MC_sampling", 2);
+  iSpectraSampler_ptr_->paraRdr_ptr->setVal("MC_sampling", 4);
 
   iSpectraSampler_ptr_->paraRdr_ptr->setVal(
       "sample_upto_desired_particle_number", 0);
@@ -100,6 +104,8 @@ void iSpectraSamplerWrapper::InitTask() {
 }
 
 void iSpectraSamplerWrapper::Exec() {
+  JSINFO << "running iSS ...";
+
   // generate symbolic links with music_input_file
   std::string music_input_file_path = GetXMLElementText(
           {"Hydro", "MUSIC", "MUSIC_input_file"});
@@ -131,6 +137,7 @@ void iSpectraSamplerWrapper::Exec() {
     exit(-1);
   }
   PassHadronListToJetscape();
+  JSINFO << "iSS finished.";
 }
 
 void iSpectraSamplerWrapper::Clear() {

--- a/src/hydro/MusicWrapper.cc
+++ b/src/hydro/MusicWrapper.cc
@@ -54,6 +54,9 @@ void MpiMusic::InitializeHydro(Parameter parameter_list) {
   music_hydro_ptr = std::unique_ptr<MUSIC>(new MUSIC(input_file));
 
   // overwrite input options
+  int echoLevel = GetXMLElementInt({"vlevel"});
+  music_hydro_ptr->set_parameter("JSechoLevel", echoLevel);
+
   flag_output_evo_to_file = (
       GetXMLElementInt({"Hydro", "MUSIC", "output_evolution_to_file"}));
   if (flag_output_evo_to_file == 1) {


### PR DESCRIPTION
Passing the <vlevel> parameter to MUSIC and iSS modules to control the amount of screen output. When <vlevel> = 0, not screen output from these two module during the execution time.