### PR TITLE
Bug fixes, C++17, softMomentumCutoff

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -93,7 +93,7 @@ endif (USE_SMASH)
 ### Compiler & Linker Flags ###
 ###############################
 message("Compiler and Linker flags ...")
-set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fPIC -pipe -Wall -std=c++11")
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fPIC -pipe -Wall -std=c++17")
 ## can turn off some warnings
 set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-reorder -Wno-unused-variable ")
 ## Then set the build type specific options. These will be automatically appended.

--- a/config/jetscape_main.xml
+++ b/config/jetscape_main.xml
@@ -99,6 +99,8 @@
       <pTHatMin>100</pTHatMin>
       <pTHatMax>120</pTHatMax>
       <eCM>5020</eCM>
+      <!-- The soft momentum cutoff in GeV removes partons from the pythia gun. The default matches the PP19 setup. -->
+      <softMomentumCutoff>2.0</softMomentumCutoff>
       <!-- You can add any number of additional lines to initialize pythia here -->
       <!-- Note that if the tag exists it cannot be empty (tinyxml produces a segfault) -->
       <LinesToRead>

--- a/config/jetscape_user_FSFileTest.xml
+++ b/config/jetscape_user_FSFileTest.xml
@@ -26,7 +26,6 @@
       <PGun>
         <name>PGun</name>
         <pT>100</pT>
-        <useHybridHad>0</useHybridHad>
       </PGun>
   </Hard>
 

--- a/config/jetscape_user_HydroFile.xml
+++ b/config/jetscape_user_HydroFile.xml
@@ -26,7 +26,6 @@
       <PGun>
         <name>PGun</name>
         <pT>100</pT>
-        <useHybridHad>0</useHybridHad>
       </PGun>
   </Hard>
 

--- a/config/jetscape_user_pbpb_grid.xml
+++ b/config/jetscape_user_pbpb_grid.xml
@@ -1,11 +1,11 @@
 <?xml version="1.0"?>
 
 <jetscape>
-  
+
   <nEvents> 5 </nEvents>
   <setReuseHydro> true </setReuseHydro>
   <nReuseHydro> 10 </nReuseHydro>
-  
+
   <JetScapeWriterAscii> on </JetScapeWriterAscii>
   <outputFilename>test_out</outputFilename>
   <vlevel> 0 </vlevel>
@@ -19,7 +19,7 @@
     <!-- initial_profile_path  /wsu/home/groups/maj-shen/JETSCAPEDataFile/HydroProfiles/5020GeV_0-10  initial_profile_path -->
      <initial_profile_path>../examples/test_hydro_files</initial_profile_path>
   </IS>
-  
+
   <!-- Hard Process -->
   <Hard>
     <PythiaGun>
@@ -30,24 +30,23 @@
       <!-- You can add any number of additional lines to initialize pythia here -->
       <!-- Note that if the tag exists it cannot be empty (tinyxml produces a segfault) -->
       <!-- EPS09 Avg Nuclear PDF for nucleon in Pb nucleus -->
-      <LinesToRead> 
+      <LinesToRead>
 	HardQCD:all = on
         PDF:useHardNPDFA=on
 	PDF:useHardNPDFB=on
-	PDF:nPDFSetA=1         
+	PDF:nPDFSetA=1
 	PDF:nPDFSetB=1
 	PDF:nPDFBeamA = 100822080
 	PDF:nPDFBeamB = 100822080
       </LinesToRead>
-      <useHybridHad>0</useHybridHad>
     </PythiaGun>
   </Hard>
-  
+
   <!--Preequilibrium Dynamics Module -->
   <Preequilibrium>
     <NullPreDynamics> </NullPreDynamics>
   </Preequilibrium>
-  
+
   <!-- Hydro  Module  -->
   <Hydro>
     <hydro_from_file>
@@ -57,7 +56,7 @@
       <hydro_files_folder>../examples/test_hydro_files</hydro_files_folder>
     </hydro_from_file>
   </Hydro>
-  
+
   <!--Eloss Modules -->
   <Eloss>
 
@@ -108,7 +107,7 @@
       <run_alphas>1</run_alphas>   <!-- 0 for fixed alpha_s and 1 for running alpha_s -->
     </Lbt>
   </Eloss>
-  
+
   <!-- Jet Hadronization Module -->
   <JetHadronization>
     <name>colorless</name>
@@ -118,5 +117,5 @@
       111:mayDecay = off
     </LinesToRead>
   </JetHadronization>
-  
+
 </jetscape>

--- a/config/jetscape_user_twostagehydro.xml
+++ b/config/jetscape_user_twostagehydro.xml
@@ -6,7 +6,7 @@
   <setReuseHydro> true </setReuseHydro>
   <nReuseHydro> 5 </nReuseHydro>
   <vlevel> 0 </vlevel>
-  
+
   <!-- Jetscape Writer -->
   <JetScapeWriterAscii> on </JetScapeWriterAscii>
 
@@ -20,7 +20,6 @@
       <PGun>
         <name>PGun</name>
         <pT>100</pT>
-        <useHybridHad>0</useHybridHad>
       </PGun>
   </Hard>
 
@@ -35,7 +34,7 @@
       <name>MUSIC_1</name>
     </MUSIC>
   </Hydro>
-  
+
   <!-- Create liquifier -->
   <Liquefier>
       <!-- CausalLiquefier -->
@@ -51,7 +50,7 @@
           <width_delta>0.1</width_delta><!-- in [fm] -->
       </CausalLiquefier>
   </Liquefier>
-  
+
   <!--Eloss Modules -->
   <Eloss>
       <deltaT>0.1</deltaT>
@@ -92,7 +91,7 @@
       </Lbt>
     <AddLiquefier> true </AddLiquefier>
   </Eloss>
-  
+
   <!-- Hydro  Module 2 -->
   <Hydro>
     <MUSIC>
@@ -100,7 +99,7 @@
     </MUSIC>
     <AddLiquefier> true </AddLiquefier>
   </Hydro>
-  
+
   <!-- Jet Hadronization Module -->
   <JetHadronization>
     <name>colorless</name>
@@ -112,5 +111,5 @@
   <SoftParticlization>
     <iSS> </iSS>
   </SoftParticlization>
-  
+
 </jetscape>

--- a/external_packages/smash/smash_config.yaml
+++ b/external_packages/smash/smash_config.yaml
@@ -10,20 +10,20 @@ General:
     Nevents:       1      # Dummy
 
 Modi:
-    List: 
+    List:
         File_Directory: .
         File_Prefix: "dummy"
         Shift_Id: 0
 
 
-# if some SMASH output in OSCAR,... format is wanted, then uncomment 
+# if some SMASH output in OSCAR,... format is wanted, then uncomment
 # the following lines and add a 'smash_output' folder to your build folder
 Output:
     Output_Interval:  100.0
 #    Particles:
 #        Format:    ["Oscar2013"]
 #        Extended: True
-#        Only_Final: True
+#        Only_Final: Yes
 #    Collisions:
 #        Format:    ["Oscar2013"]
 #        Extended: True

--- a/src/initialstate/PythiaGun.cc
+++ b/src/initialstate/PythiaGun.cc
@@ -70,10 +70,10 @@ void PythiaGun::InitTask() {
   readString("PromptPhoton:all=on");
   readString("WeakSingleBoson:all=off");
   readString("WeakDoubleBoson:all=off");
-  
+
   pTHatMin = GetXMLElementDouble({"Hard", "PythiaGun", "pTHatMin"});
   pTHatMax = GetXMLElementDouble({"Hard", "PythiaGun", "pTHatMax"});
-  
+
   if(pTHatMin < 0.01){ //assuming low bin where softQCD should be used
     //running softQCD - inelastic nondiffrative (min-bias)
     readString("HardQCD:all = off");
@@ -208,8 +208,14 @@ void PythiaGun::Exec() {
 
         // reject rare cases of very soft particles that don't have enough e to get
         // reasonable virtuality
-        if (particle.pT() < 1.0 / sqrt(vir_factor))
+        if (vir_factor > 0. && (particle.pT() < 1.0 / sqrt(vir_factor))) {
           continue;
+        } else if(vir_factor < 0. && (particle.pAbs() < 1.0 / sqrt(abs(vir_factor)))) {
+          continue;
+        } else {
+          JSWARN << "vir_factor should not be zero.";
+          exit(1);
+        }
 
         //if(particle.id()==22) cout<<"########this is a photon!######" <<endl;
         // accept

--- a/src/initialstate/PythiaGun.h
+++ b/src/initialstate/PythiaGun.h
@@ -2,7 +2,7 @@
  * Copyright (c) The JETSCAPE Collaboration, 2018
  *
  * Modular, task-based framework for simulating all aspects of heavy-ion collisions
- * 
+ *
  * For the list of contributors see AUTHORS.
  *
  * Report issues at https://github.com/JETSCAPE/JETSCAPE/issues
@@ -30,6 +30,8 @@ private:
   double pTHatMin;
   double pTHatMax;
   double eCM;
+  double vir_factor;
+  double softMomentumCutoff;
   bool FSR_on;
   bool softQCD;
 

--- a/src/jet/Matter.cc
+++ b/src/jet/Matter.cc
@@ -487,7 +487,7 @@ void Matter::DoEnergyLoss(double deltaT, double time, double Q2,
       double max_vir;
       if (vir_factor < 0.0)
         max_vir =
-            pIn[i].e() * pIn[i].e() - pIn[i].restmass() * pIn[i].restmass();
+            std::abs(vir_factor) * (pIn[i].e() * pIn[i].e() - pIn[i].restmass() * pIn[i].restmass());
       else
         max_vir = pT2 * vir_factor;
 

--- a/src/jet/Matter.cc
+++ b/src/jet/Matter.cc
@@ -2,7 +2,7 @@
  * Copyright (c) The JETSCAPE Collaboration, 2018
  *
  * Modular, task-based framework for simulating all aspects of heavy-ion collisions
- * 
+ *
  * For the list of contributors see AUTHORS.
  *
  * Report issues at https://github.com/JETSCAPE/JETSCAPE/issues
@@ -770,9 +770,9 @@ void Matter::DoEnergyLoss(double deltaT, double time, double Q2,
 		}*/
 
 	    //GeneralQhatFunction(int QhatParametrizationType, double Temperature, double EntropyDensity, double FixAlphas,  double Qhat0, double E, double muSquare)
-	    double muSquare= pIn[i].t(); //Virtuality of the parent; Revist this when q-hat is virtuality dependent 
+	    double muSquare= pIn[i].t(); //Virtuality of the parent; Revist this when q-hat is virtuality dependent
 	    qhatLoc= GeneralQhatFunction(QhatParametrizationType, tempLoc, sdLoc, alphas, qhat0, enerLoc, muSquare);
-	  
+
           } else { // outside the QGP medium
             continue;
           }
@@ -786,19 +786,19 @@ void Matter::DoEnergyLoss(double deltaT, double time, double Q2,
 	  //if(run_alphas==1){ alphas= 4*pi/(9.0*log(2*enerLoc*tempLoc/0.04));}
 
           // solve alphas
-          if (qhat0 < 0.0 || QhatParametrizationType==0 || QhatParametrizationType==1 || QhatParametrizationType==5 || 
+          if (qhat0 < 0.0 || QhatParametrizationType==0 || QhatParametrizationType==1 || QhatParametrizationType==5 ||
               QhatParametrizationType==6 || QhatParametrizationType==7 )
             soln_alphas = alphas;
           else
             soln_alphas = solve_alphas(qhatLoc, enerLoc, tempLoc);
-          
+
           // Calculate the proability of elastic scattering in time delta t in fluid rest frame
           muD2 = 6.0 * pi * soln_alphas * tempLoc * tempLoc;
           prob_el = 42.0 * zeta3 * el_CR  * tempLoc / 6.0 / pi /
                     pi * dt_lrf / 0.1973;
-		  
+
 	  prob_el=prob_el*ModifiedProbability(QhatParametrizationType, tempLoc, sdLoc, enerLoc, pIn[i].t());
-	    
+
           el_rand = ZeroOneDistribution(*GetMt19937Generator());
 
           //cout << "  qhat: " << qhatLoc << "  alphas: " << soln_alphas << "  ener: " << enerLoc << "  prob_el: " << prob_el << "  " << el_rand << endl;
@@ -2008,7 +2008,7 @@ double Matter::generate_vac_t_w_M(int p_id, double M, double nu, double t0,
   t_hi_00 = t;
 
   tscale = t; //for virtuality dependent q-hat
-  
+
   VERBOSE(1) << MAGENTA << " in gen_vac_t_w_M : t_low , t_hi = " << t_low_M0 << "  " << t ;
   //cin >> test ;
 
@@ -2126,10 +2126,10 @@ double Matter::generate_vac_t_w_M(int p_id, double M, double nu, double t0,
     }
 
     if (std::abs(p_id) == cid || std::abs(p_id) == bid)
-      exit_condition = (std::abs(diff) < s_approx) &&
+      exit_condition = (std::abs(diff) < s_approx) ||
                        (std::abs(t_hi_M0 - t_low_M0) / t_hi_M0 < s_error);
     if (p_id == gid)
-      exit_condition = (std::abs(diff) < s_approx) &&
+      exit_condition = (std::abs(diff) < s_approx) ||
                        (std::abs(t_hi_00 - t_low_00) / t_hi_00 < s_error);
     // need to think about the second statement in the gluon exit condition.
 
@@ -2142,13 +2142,13 @@ double Matter::generate_vac_t_w_M(int p_id, double M, double nu, double t0,
 }
 
 /*
- 
- 
- 
+
+
+
   New function
- 
- 
- 
+
+
+
 */
 
 double Matter::generate_vac_z(int p_id, double t0, double t, double loc_b,
@@ -3841,7 +3841,7 @@ double Matter::fillQhatTab(double y) {
       // GeneralQhatFunction(int QhatParametrizationType, double Temperature, double EntropyDensity, double FixAlphas,  double Qhat0, double E, double muSquare);
       double muSquare=-1;//For virtuality dependent cases, we explicitly modify q-hat inside Sudakov, due to which we set here scale=-1; Alternatively one could extend the dimension of the q-hat table
 
-      qhatLoc= GeneralQhatFunction(QhatParametrizationType, tempLoc, sdLoc, alphas, qhat0, initEner, muSquare);      
+      qhatLoc= GeneralQhatFunction(QhatParametrizationType, tempLoc, sdLoc, alphas, qhat0, initEner, muSquare);
       qhatLoc = qhatLoc * flowFactor;
 
       //JSINFO << "check qhat --  ener, T, qhat: " << initEner << " , " << tempLoc << " , " << qhatLoc;
@@ -3874,22 +3874,22 @@ double Matter::fillQhatTab(double y) {
 double Matter::GeneralQhatFunction(int QhatParametrization, double Temperature, double EntropyDensity, double FixAlphas, double Qhat0, double E, double muSquare)
 {
   int ActiveFlavor=3; qhat=0.0;
-  double DebyeMassSquare = FixAlphas*4*pi*pow(Temperature,2.0)*(6.0 + ActiveFlavor)/6.0; 
-  double ScaleNet=2*E*Temperature; 
+  double DebyeMassSquare = FixAlphas*4*pi*pow(Temperature,2.0)*(6.0 + ActiveFlavor)/6.0;
+  double ScaleNet=2*E*Temperature;
   if(ScaleNet < 1.0){ ScaleNet=1.0; }
   switch(QhatParametrization)
     {
       //HTL formula with all alpha_s as constant and controlled by XML
     case 0:
-      qhat = (Ca*50.4864/pi)*pow(FixAlphas,2)*pow(Temperature,3)*log(ScaleNet/DebyeMassSquare); 
+      qhat = (Ca*50.4864/pi)*pow(FixAlphas,2)*pow(Temperature,3)*log(ScaleNet/DebyeMassSquare);
       break;
-      
+
       //alpha_s at scale muS=2ET and second alpha_s at muS=DebyeMassSquare is fit parameter
-    case 1:	
+    case 1:
       qhat = (Ca*50.4864/pi)*RunningAlphaS(ScaleNet)*FixAlphas*pow(Temperature,3)*log(ScaleNet/DebyeMassSquare);
       break;
-      
-      //Constant q-hat 
+
+      //Constant q-hat
     case 2:
     qhat = Qhat0*0.1973;
     break;
@@ -3898,36 +3898,36 @@ double Matter::GeneralQhatFunction(int QhatParametrization, double Temperature, 
     case 3:
     qhat = Qhat0*pow(Temperature/0.3,3)*0.1973; // w.r.t T=0.3 GeV
     break;
-  
+
     //Scale with entropy density
     case 4:
     qhat = Qhat0*(EntropyDensity/96.0)*0.1973; // w.r.t S0=96 fm^-3
     break;
-    
-    //HTL q-hat multiplied by Virtuality dependent function to mimic PDF-Scale dependent q-hat  
-    //Function is 1/(1+A*pow(log(Q^2),2)+B*pow(log(Q^2),4)) 
+
+    //HTL q-hat multiplied by Virtuality dependent function to mimic PDF-Scale dependent q-hat
+    //Function is 1/(1+A*pow(log(Q^2),2)+B*pow(log(Q^2),4))
     case 5:
       qhat = (Ca*50.4864/pi)*RunningAlphaS(ScaleNet)*FixAlphas*pow(Temperature,3)*log(ScaleNet/DebyeMassSquare);
       qhat = qhat*VirtualityQhatFunction(5, E, muSquare);
     break;
-    
+
     //HTL q-hat multiplied by Virtuality dependent function to mimic PDF-Scale dependent q-hat
-    //Function is int^{1}_{xB} e^{-ax} / (1+A*pow(log(Q^2),1)+B*pow(log(Q^2),2)) 
+    //Function is int^{1}_{xB} e^{-ax} / (1+A*pow(log(Q^2),1)+B*pow(log(Q^2),2))
     case 6:
       qhat = (Ca*50.4864/pi)*RunningAlphaS(ScaleNet)*FixAlphas*pow(Temperature,3)*log(ScaleNet/DebyeMassSquare);
       qhat = qhat*VirtualityQhatFunction(6, E, muSquare);
       break;
 
       //HTL q-hat multiplied by Virtuality dependent function to mimic PDF-Scale dependent q-hat
-      //Function is int^{1}_{xB} x^{a}(1-x)^{b} / (1+A*pow(log(Q^2),1)+B*pow(log(Q^2),2)) 
+      //Function is int^{1}_{xB} x^{a}(1-x)^{b} / (1+A*pow(log(Q^2),1)+B*pow(log(Q^2),2))
     case 7:
       qhat = (Ca*50.4864/pi)*RunningAlphaS(ScaleNet)*FixAlphas*pow(Temperature,3)*log(ScaleNet/DebyeMassSquare);
       qhat = qhat*VirtualityQhatFunction(7, E, muSquare);
       break;
 
-    default:      
-      JSINFO<<"q-hat Parametrization "<<QhatParametrization<<" is not used, qhat will be set to zero";    
-    }  
+    default:
+      JSINFO<<"q-hat Parametrization "<<QhatParametrization<<" is not used, qhat will be set to zero";
+    }
   return qhat;
 }
 
@@ -3938,7 +3938,7 @@ double Matter::RunningAlphaS(double muSquare)
   double Square_Lambda_QCD_HTL = exp( -12.0*pi/( (33 - 2*ActiveFlavor)*alphas) );
   double ans = 12.0*pi/( (33.0- 2.0*ActiveFlavor)*log(muSquare/Square_Lambda_QCD_HTL) );
   if(muSquare < 1.0) {ans=alphas; }
-  
+
   VERBOSE(8)<<"Fixed-alphaS="<<alphas<<", Lambda_QCD_HTL="<<sqrt(Square_Lambda_QCD_HTL)<<", mu2="<<muSquare<<", Running alpha_s"<<ans;
   return ans;
 }
@@ -3950,35 +3950,35 @@ double Matter::VirtualityQhatFunction(int QhatParametrization,  double enerLoc, 
 
   if( muSquare <= Q00*Q00) {ans=1;}
   else
-    {  
+    {
       switch(QhatParametrization)
 	{
 	case 0:
           ans =  1.0;
           break;
-	  
+
 	case 1:
           ans =  1.0;
           break;
 
 	case 2:
           ans =  1.0;
-          break;  
-	  
+          break;
+
 	case 3:
           ans =  1.0;
           break;
 
 	case 4:
           ans =  1.0;
-          break;  
+          break;
 
 	case 5:
 	  ans =  1.0 + qhatA*log(Q00*Q00)*log(Q00*Q00) + qhatB*pow(log(Q00*Q00),4);
 	  ans = ans/( 1.0 + qhatA*log(muSquare)*log(muSquare) + qhatB*pow(log(muSquare),4)  );
 	  break;
-	  
-	case 6: 
+
+	case 6:
 	  xB  = muSquare/(2.0*enerLoc);
 	  xB0 = Q00*Q00/(2.0*enerLoc); if(xB<=xB0){ans=1.0; break; }
 	  if ( qhatC > 0.0 && xB < 0.99)
@@ -3992,7 +3992,7 @@ double Matter::VirtualityQhatFunction(int QhatParametrization,  double enerLoc, 
 	      ans = (1.0-xB)/(1.0 + qhatA*log(muSquare/0.04) + qhatB*log(muSquare/0.04)*log(muSquare/0.04) );
 	      ans = ans*(1.0 + qhatA*log(Q00*Q00/0.04) + qhatB*log(Q00*Q00/0.04)*log(Q00*Q00/0.04) )/(1-xB0);
 	    }
-	  else {ans=0.0;}	  
+	  else {ans=0.0;}
 	  //JSINFO<<"L xB="<<xB<<", and (E,muSquare)=("<<enerLoc<<","<<muSquare<<"), and Virtuality dep Qhat="<<ans;
           break;
 
@@ -4006,16 +4006,16 @@ double Matter::VirtualityQhatFunction(int QhatParametrization,  double enerLoc, 
 	      ans=ans*(1.0 + qhatA*log(muSquare/0.04) + qhatB*log(muSquare/0.04)*log(muSquare/0.04) )/IntegralNorm;
 	    }
 	  else {ans=0;}
-	  //JSINFO<<"L xB="<<xB<<", and (E,muSquare)=("<<enerLoc<<","<<muSquare<<"), and Virtuality dep Qhat="<<ans; 
+	  //JSINFO<<"L xB="<<xB<<", and (E,muSquare)=("<<enerLoc<<","<<muSquare<<"), and Virtuality dep Qhat="<<ans;
 	  break;
-	  
+
 	default:
 	  JSINFO<<"q-hat Parametrization "<<QhatParametrization<<" is not used, VirtualityQhatFunction is set to zero or one";
 	}
     }
 
   //JSINFO<<"Qhat Type="<<QhatParametrization<<", and (E,muSquare)=("<<enerLoc<<","<<muSquare<<"), and Virtuality dep Qhat="<<ans;
-  return ans;  
+  return ans;
 }
 ////////////Modification of elastic scattering probability due to modified q-hat//////
 double Matter::ModifiedProbability(int QhatParametrization, double tempLoc, double sdLoc, double enerLoc, double muSquare)
@@ -4023,7 +4023,7 @@ double Matter::ModifiedProbability(int QhatParametrization, double tempLoc, doub
   double ModifiedAlphas=0;double qhatLoc=0;
   double ScaleNet=2*enerLoc*tempLoc;
   if(ScaleNet <1.0) { ScaleNet=1.0; }
-  
+
   switch(QhatParametrization)
     {
       //For HTL q-hat formula with all alpha_s as constant and controlled by XML
@@ -4032,16 +4032,16 @@ double Matter::ModifiedProbability(int QhatParametrization, double tempLoc, doub
       break;
 
       //For HTL q-hat where one alpha_s at scale muS=2ET and second alpha_s at muS=DebyeMassSquare is fit parameter
-    case 1:      
+    case 1:
       ModifiedAlphas = RunningAlphaS(ScaleNet);
       break;
 
       //Constant q-hat case, alphas is computed using HTL formula with all alpha_s fixed
     case 2:
       qhatLoc = qhat0*0.1973;
-      ModifiedAlphas = solve_alphas(qhatLoc, enerLoc, tempLoc);  
+      ModifiedAlphas = solve_alphas(qhatLoc, enerLoc, tempLoc);
       break;
-      
+
       //For q-hat goes as T^3, alphas is computed using HTL formula with all alpha_s fixed
     case 3:
       qhatLoc = qhat0*pow(tempLoc/0.3,3)*0.1973; // w.r.t T=0.3 GeV
@@ -4055,24 +4055,24 @@ double Matter::ModifiedProbability(int QhatParametrization, double tempLoc, doub
       break;
 
       //For HTL q-hat multiplied by Virtuality dependent function to mimic PDF-Scale dependent q-hat
-      //Function is 1 / (1+A*pow(log(Q^2),2)+B*pow(log(Q^2),4))   
+      //Function is 1 / (1+A*pow(log(Q^2),2)+B*pow(log(Q^2),4))
     case 5:
       ModifiedAlphas = RunningAlphaS(ScaleNet)*VirtualityQhatFunction(5,  enerLoc, muSquare) ;
       break;
-      //HTL q-hat multiplied by Virtuality dependent function to mimic PDF-Scale dependent q-hat 
-      //Function is int^{1}_{xB} e^{-ax} / (1+A*pow(log(Q^2),1)+B*pow(log(Q^2),2)) 
+      //HTL q-hat multiplied by Virtuality dependent function to mimic PDF-Scale dependent q-hat
+      //Function is int^{1}_{xB} e^{-ax} / (1+A*pow(log(Q^2),1)+B*pow(log(Q^2),2))
     case 6:
       ModifiedAlphas = RunningAlphaS(ScaleNet)*VirtualityQhatFunction(6,  enerLoc, muSquare) ;
       break;
 
       //HTL q-hat multiplied by Virtuality dependent function to mimic PDF-Scale dependent q-hat
-      //Function is int^{1}_{xB} x^{a}(1-x)^{b} / (1+A*pow(log(Q^2),1)+B*pow(log(Q^2),2))  
+      //Function is int^{1}_{xB} x^{a}(1-x)^{b} / (1+A*pow(log(Q^2),1)+B*pow(log(Q^2),2))
     case 7:
       ModifiedAlphas = RunningAlphaS(ScaleNet)*VirtualityQhatFunction(7,  enerLoc, muSquare) ;
       break;
-      
-    default:      
-      JSINFO<<"q-hat Parametrization "<<QhatParametrization<<" is not used,Elastic scattering alphas will be set to zero"; 
+
+    default:
+      JSINFO<<"q-hat Parametrization "<<QhatParametrization<<" is not used,Elastic scattering alphas will be set to zero";
     }
   //JSINFO<<"q-hat Parametrization "<<QhatParametrization<<" modified alphas="<<ModifiedAlphas;
   return ModifiedAlphas;
@@ -4137,7 +4137,7 @@ double Matter::fncAvrQhat(double zeta, double tau) {
     return (0);
   if (indexTau >= dimQhatTab)
     indexTau = dimQhatTab - 1;
-  
+
   double avrQhat = qhatTab2D[indexZeta][indexTau]*VirtualityQhatFunction(QhatParametrizationType, initEner, tscale);
   return (avrQhat);
 }
@@ -4531,7 +4531,7 @@ void Matter::colljet22(int CT, double temp, double qhat0ud, double v0[4],
 
     f1 = pow(xw, 3) / (exp(xw) - 1) / 1.4215;
     f2 = pow(xw, 3) / (exp(xw) + 1) / 1.2845;
- 
+
     uu = ss - tt;
 
     if (CT == 1) {


### PR DESCRIPTION
This PR fixes the bug in the Matter logic and closes #157. It introduces the `vir_factor` in the case of a negative parameter such that the parameter allows for a user handling of the maximum virtuality in this case.

The PR fixes the `sigmaGen` and `sigmaErr` reader and closes #155.

C++17 is now used to compile the code and the outdated `<useHybridHad>` flag is removed from all config files.

In the PythiaGun the xml parameters are moved to the init function and a new parameter `<softMomentumCutoff>` is introduced to handle the low momentum cutoff in the initial state. The default value is set such that the setup from the PP19 paper is implemented. In the case of a negative `vir_factor` the absolute three momentum is used to be consistent with the handling in the Matter module.