### PR TITLE
Higher verbosity level for CheckOrForceHadron warning

### DIFF
--- a/src/framework/JetScapeParticles.cc
+++ b/src/framework/JetScapeParticles.cc
@@ -491,7 +491,7 @@ bool Hadron::CheckOrForceHadron(const int id, const double mass) {
   // -- Add unknown particles
   if (!InternalHelperPythia.particleData.isParticle(
           id)) { // avoid doing it over and over
-    JSWARN << "id = " << id << " is not recognized as a hadron! "
+    VERBOSE(7) << "id = " << id << " is not recognized as a hadron! "
            << "Add it as a new type of particle.";
     InternalHelperPythia.particleData.addParticle(id, " ", 0, 0, 0, mass, 0.1);
   }


### PR DESCRIPTION
In the COMP meeting, we decided to set the CheckOrForceHadron warning to a higher verbosity level. It is not informative for the user and unnecessary to print this out in all the production runs.