### PR TITLE
updates external repo get scripts to use set commit hashes

### DIFF
--- a/external_packages/get_freestream-milne.sh
+++ b/external_packages/get_freestream-milne.sh
@@ -16,7 +16,15 @@
 # download the 3+1D OSU freestreaming code
 #git clone --depth=1 https://github.com/derekeverett/freestream-milne.git freestream-milne
 #git clone --depth=1 https://github.com/derekeverett/freestream-milne.git -b time_step_history freestream-milne
-git clone --depth=1 https://github.com/chunshen1987/freestream-milne -b time_step_history freestream-milne
+#git clone --depth=1 https://github.com/chunshen1987/freestream-milne -b time_step_history freestream-milne
+
+# using a commit from the freestream-milne repository that is compatible with JETSCAPE 3.6.1
+folderName="freestream-milne"
+commitHash="eb51fd6ff5a547f08bf817e728794dfce6177db4"
+
+git clone https://github.com/chunshen1987/freestream-milne -b time_step_history $folderName
+cd $folderName
+git checkout $commitHash
 
 #cd freestream-milne
 #patch -p0 -Ni ../freestream-milne-external-params.patch

--- a/external_packages/get_iSS.sh
+++ b/external_packages/get_iSS.sh
@@ -14,5 +14,12 @@
 ##############################################################################
 
 # download the code package
-git clone --depth=1 https://github.com/chunshen1987/iSS -b JETSCAPE iSS
+# git clone --depth=1 https://github.com/chunshen1987/iSS -b JETSCAPE iSS
 
+# using a commit from the iSS repository that is compatible with JETSCAPE 3.6.1
+folderName="iSS"
+commitHash="2471dcc0e74c4a2d86c08ae82ad4304643b30439"
+
+git clone https://github.com/chunshen1987/iSS -b JETSCAPE $folderName
+cd $folderName
+git checkout $commitHash

--- a/external_packages/get_music.sh
+++ b/external_packages/get_music.sh
@@ -16,8 +16,15 @@
 # download the code package
 #git clone git://git.code.sf.net/p/music-hydro/code music
 #git clone --depth=1 git://git.code.sf.net/p/music-hydro/code music
-git clone --depth=1 https://github.com/MUSIC-fluid/MUSIC -b JETSCAPE music
+#git clone --depth=1 https://github.com/MUSIC-fluid/MUSIC -b JETSCAPE music
 
+# using a commit from the MUSIC repository that is compatible with JETSCAPE 3.6.1
+folderName="music"
+commitHash="db320898c4a9bd99ed21aa9dbb7c78e2cb0729bd"
+
+git clone https://github.com/MUSIC-fluid/MUSIC -b JETSCAPE $folderName
+cd $folderName
+git checkout $commitHash
 
 ### ALTERNATIVE VERSION
 ### Download a zipped snapshot


### PR DESCRIPTION
This PR amends the get_freestream-milne.sh, get_iSS.sh, and get_music.sh scripts to checkout specific commit hashes of these repositories, so future external repository updates won't impact the JETSCAPE 3.6.1 public release.