### PR TITLE
Remove unused include for omp

### DIFF
--- a/src/hadronization/ThermPtnSampler.cc
+++ b/src/hadronization/ThermPtnSampler.cc
@@ -3,7 +3,6 @@
 #include "JetScapeXML.h"
 #include "JetScapeLogger.h"
 #include "JetScapeConstants.h"
-#include <omp.h>
 #include <vector>
 #include <random>
 #include <cmath>


### PR DESCRIPTION
This removes the unused include for `omp.h` in the ThermPtnSampled.cc
It solves issue #172.