### PR TITLE
Eloss Matter seed corr

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,7 +106,7 @@ If you encounter a problem, please report the issue [here](https://github.com/JE
 Please be sure to include enough information so that we can reproduce your issue: your platform, JETSCAPE version,
 configuration file, and anything else that may be relevant.
 
-## Contributing to JETSCAPE
+## Contributing to JETSCAP
 
 If you would like to contribute code to JETSCAPE (new module, feature, bug fix, etc.) please open 
 a [Pull Request](https://github.com/JETSCAPE/JETSCAPE/pulls) with your changes, or an [Issue](https://github.com/JETSCAPE/JETSCAPE/issues) describing what you intend to do. For further details, see [Tips for git management](https://github.com/JETSCAPE/JETSCAPE/wiki/Tips-for-git-management).

--- a/README.md
+++ b/README.md
@@ -106,7 +106,7 @@ If you encounter a problem, please report the issue [here](https://github.com/JE
 Please be sure to include enough information so that we can reproduce your issue: your platform, JETSCAPE version,
 configuration file, and anything else that may be relevant.
 
-## Contributing to JETSCAP
+## Contributing to JETSCAPE
 
 If you would like to contribute code to JETSCAPE (new module, feature, bug fix, etc.) please open 
 a [Pull Request](https://github.com/JETSCAPE/JETSCAPE/pulls) with your changes, or an [Issue](https://github.com/JETSCAPE/JETSCAPE/issues) describing what you intend to do. For further details, see [Tips for git management](https://github.com/JETSCAPE/JETSCAPE/wiki/Tips-for-git-management).

--- a/src/jet/Matter.cc
+++ b/src/jet/Matter.cc
@@ -173,9 +173,10 @@ void Matter::Init() {
   ZeroOneDistribution = uniform_real_distribution<double>{0.0, 1.0};
 
   //...initialize the random number generator
-  srand((unsigned)time(NULL));
-  NUM1 = -1 * rand();
+  //srand((unsigned)time(NULL));
+  //NUM1 = -1 * rand();
   //    NUM1=-33;
+  NUM1=-1*static_cast<int>(ZeroOneDistribution(*GetMt19937Generator())*RAND_MAX);	
   iEvent = 0;
 }
 


### PR DESCRIPTION
Matter currently uses a random seed using srand with the current system time. Instead, Matter should initialize the random seed using the framework generated random seed for reproducibility, especially for debugging.