### PR TITLE
Fix ini pointer and revert Lambda_QCD changes

### DIFF
--- a/config/jetscape_main.xml
+++ b/config/jetscape_main.xml
@@ -130,7 +130,6 @@
     <tStart> 0.6 </tStart> <!-- Start time of jet quenching, proper time, fm/c   -->
     <mutex>ON</mutex>
     <AddLiquefier> false </AddLiquefier>
-    <lambdaQCD>0.2</lambdaQCD> <!-- 0.4 is the value chosen in JETSET -->
 
     <Matter>
       <name>Matter</name>

--- a/src/framework/JetScapeConstants.h
+++ b/src/framework/JetScapeConstants.h
@@ -31,6 +31,9 @@ static double Ca = 3.0;
 
 static double Nc = 3.0;
 
+static double Lambda_QCD = 0.2;
+// 0.4 is the value chosen in JETSET
+
 static const double hbarC = 0.197327053;
 
 static const double fmToGeVinv = 1.0 / hbarC;

--- a/src/hadronization/ColorlessHadronization.cc
+++ b/src/hadronization/ColorlessHadronization.cc
@@ -111,8 +111,6 @@ void ColorlessHadronization::Init() {
     pythia.readString(s);
   }
 
-  Lambda_QCD = GetXMLElementDouble({"Eloss","lambdaQCD"});
-
   // Initialize random number distribution
   ZeroOneDistribution = std::uniform_real_distribution<double> { 0.0, 1.0 };
   // And initialize

--- a/src/hadronization/ColorlessHadronization.h
+++ b/src/hadronization/ColorlessHadronization.h
@@ -37,7 +37,6 @@ public:
 private:
   double p_fake;
   bool take_recoil;
-  double Lambda_QCD;
 
   // Allows the registration of the module so that it is available to be used by the Jetscape framework.
   static RegisterJetScapeModule<ColorlessHadronization> reg;

--- a/src/hydro/Brick.cc
+++ b/src/hydro/Brick.cc
@@ -79,7 +79,6 @@ void Brick::InitializeHydro(Parameter parameter_list) {
 
 void Brick::EvolveHydro() {
   VERBOSE(8);
-  VERBOSE(2) << "size of sd = " << ini->GetEntropyDensityDistribution().size();
   hydro_status = FINISHED;
 }
 

--- a/src/initialstate/epemGun.cc
+++ b/src/initialstate/epemGun.cc
@@ -140,8 +140,6 @@ void epemGun::InitTask() {
     throw std::runtime_error("Pythia init() failed.");
   }
 
-  Lambda_QCD = GetXMLElementDouble({"Eloss","lambdaQCD"});
-
   // Initialize random number distribution
   ZeroOneDistribution = uniform_real_distribution<double>{0.0, 1.0};
 

--- a/src/initialstate/epemGun.h
+++ b/src/initialstate/epemGun.h
@@ -31,7 +31,6 @@ private:
   //double pTHatMax;
   double eCM;
   //bool FSR_on;
-  double Lambda_QCD;
 
   // Allows the registration of the module so that it is available to be used by the Jetscape framework.
   static RegisterJetScapeModule<epemGun> reg;

--- a/src/jet/Matter.cc
+++ b/src/jet/Matter.cc
@@ -142,7 +142,6 @@ void Matter::Init() {
   hydro_Tc = GetXMLElementDouble({"Eloss", "Matter", "hydro_Tc"});
   brick_length = GetXMLElementDouble({"Eloss", "Matter", "brick_length"});
   vir_factor = GetXMLElementDouble({"Eloss", "Matter", "vir_factor"});
-  Lambda_QCD = GetXMLElementDouble({"Eloss","lambdaQCD"});
 
   if (vir_factor < 0.0) {
     cout << "Reminder: negative vir_factor is set, initial energy will be used "

--- a/src/jet/Matter.h
+++ b/src/jet/Matter.h
@@ -108,7 +108,6 @@ public:
   double initR0, initRx, initRy, initRz, initVx, initVy, initVz, initRdotV,
       initVdotV, initEner;
   double Q00, Q0, T0;
-  double Lambda_QCD;
 
   static const int dimQhatTab = 151;
   double qhatTab1D[dimQhatTab] = {0.0};


### PR DESCRIPTION
This PR implements:
- Removal of the `ini` pointer in the Brick module.
- Revert the change from JS 3.6.1, where `Lambda_QCD` was made a parameter in the XML file. This is the result of the discussion with @amajumder after the COMP meeting today. We will use this as a variable parameter in private branches or forks of the repository, but not in the publicly available code, where any user can change the value easily. This has too much potential to mess up the physics results by inexperienced users.