### PR TITLE
Remove obsolete option in AA user config

### DIFF
--- a/config/jetscape_user_pbpb_grid.xml
+++ b/config/jetscape_user_pbpb_grid.xml
@@ -68,7 +68,6 @@
 
     <Matter>
       <name>Matter</name>
-      <useHybridHad>0</useHybridHad>
       <matter_on> 1 </matter_on>
       <Q0> 2.0 </Q0>
       <T0> 0.16 </T0>


### PR DESCRIPTION
Per https://github.com/JETSCAPE/JETSCAPE/pull/168 , the `useHybridHad` config option was noted to be obsolete and was removed from most configuration files, including the `jetscape_main.xml` (I haven't yet found the commit that actually makes the option obsolete, so it would be good to confirm. Searching the codebase yields no other references to it, so I think it's fine). However, it appears that this configuration file was overlooked in removing the option, which prevents it from running. This PR removes the option

cc: @LipeiDu 