### PR TITLE
fix the clean up order when nReUseHydro > 1

### DIFF
--- a/src/hadronization/iSpectraSamplerWrapper.cc
+++ b/src/hadronization/iSpectraSamplerWrapper.cc
@@ -259,6 +259,5 @@ int iSpectraSamplerWrapper::getSurfCellVector() {
     FOsurf_array.push_back(iSS_surf_cell);
   }
   iSpectraSampler_ptr_->getSurfaceCellFromJETSCAPE(FOsurf_array);
-  ClearHydroHyperSurface();
   return(nCells);
 }

--- a/src/hydro/MusicWrapper.cc
+++ b/src/hydro/MusicWrapper.cc
@@ -268,6 +268,7 @@ void MpiMusic::EvolveHydro() {
   }
 
   if (flag_surface_in_memory == 1) {
+    clearSurfaceCellVector();
     PassHydroSurfaceToFramework();
   } else {
     collect_freeze_out_surface();


### PR DESCRIPTION
@LipeiDu reported a runtime error when setting nReUseHydro > 1. The clear of the surface cell vector needs to be called with hydro, not inside iSS.

This pull request fixed this runtime error.
