### PR TITLE
Fix bug when not decaying hadrons Hybrid Hadronization (Pythia)

### DIFF
--- a/src/hadronization/HybridHadronization.cc
+++ b/src/hadronization/HybridHadronization.cc
@@ -709,6 +709,10 @@ void HybridHadronization::DoHadronization(vector<vector<shared_ptr<Parton>>>& sh
       } //do this only if there are negative partons, otherwise the baryon recombination would be switched off after the first event without negative partons
     }
     if(HH_shower.num() == 0){
+      th_recofactor = tmp_threco;
+      maxB_level = tmp_maxB_level;
+      reco_hadrons_pythia = tmp_reco_hadrons_pythia;
+      if(pythia_decays == "off"){pythia.readString("HadronLevel:Decay = off"); pythia.init();}
       continue;
     } //attempting to handle events/configurations with 0 partons will result in a crash
 


### PR DESCRIPTION
This fixes a bug where parameters are not reset to their original values after the first event in vacuum systems where no negative partons are present and the loop is exited early to avoid crashes in PYTHIA. The fix is only relevant if the hadrons should continue to propagate in the hadronic afterburner phase.

This closes #228.