### PR TITLE
remove gtl binary_function & add macOS workflow

### DIFF
--- a/.github/workflows/test-build-external.yaml
+++ b/.github/workflows/test-build-external.yaml
@@ -4,12 +4,12 @@ on:
   pull_request:
     branches:
       - main
-      - JETSCAPE-4.0-RC
+      - JETSCAPE-3.6.6-RC
       - latessa/gtl_binary_function
   push:
     branches:
       - main
-      - JETSCAPE-4.0-RC
+      - JETSCAPE-3.6.6-RC
       - latessa/gtl_binary_function
 
 env:

--- a/.github/workflows/test-build-external.yaml
+++ b/.github/workflows/test-build-external.yaml
@@ -4,13 +4,13 @@ on:
   pull_request:
     branches:
       - main
-      - JETSCAPE-3.6.5-RC
-      - latessa/dockerImage
+      - JETSCAPE-4.0-RC
+      - latessa/gtl_binary_function
   push:
     branches:
       - main
-      - JETSCAPE-3.6.5-RC
-      - latessa/dockerImage
+      - JETSCAPE-4.0-RC
+      - latessa/gtl_binary_function
 
 env:
   REPO_NAME: ${{ github.event.repository.name }}

--- a/.github/workflows/test-build-macos-native.yaml
+++ b/.github/workflows/test-build-macos-native.yaml
@@ -4,12 +4,12 @@ on:
   pull_request:
     branches:
       - main
-      - JETSCAPE-4.0-RC
+      - JETSCAPE-3.6.6-RC
       - latessa/gtl_binary_function
   push:
     branches:
       - main
-      - JETSCAPE-4.0-RC
+      - JETSCAPE-3.6.6-RC
       - latessa/gtl_binary_function
 
 env:

--- a/.github/workflows/test-build-macos-native.yaml
+++ b/.github/workflows/test-build-macos-native.yaml
@@ -25,6 +25,12 @@ jobs:
 
     steps:
 
+    - name: Set up Homebrew
+      run: |
+        brew update
+        NONINTERACTIVE=1 brew install pkgconf
+        brew link --overwrite pkgconf
+
     - name: brew install dependencies
       run: |
         NONINTERACTIVE=1 brew install --formula cmake doxygen root graph-tool hdf5 open-mpi gsl boost zlib

--- a/.github/workflows/test-build-macos-native.yaml
+++ b/.github/workflows/test-build-macos-native.yaml
@@ -28,7 +28,7 @@ jobs:
     - name: Set up Homebrew
       run: |
         brew update
-        NONINTERACTIVE=1 brew install pkgconf
+        brew install pkgconf
         brew link --overwrite pkgconf
 
     - name: brew install dependencies

--- a/.github/workflows/test-build-macos-native.yaml
+++ b/.github/workflows/test-build-macos-native.yaml
@@ -32,23 +32,14 @@ jobs:
         brew cleanup
         brew unlink pkg-config@0.29.2
         brew install --formula cmake
-        brew update
         brew install --formula doxygen
-        brew update
         brew install --formula root
-        brew update
         brew install --formula graph-tool
-        brew update
         brew install --formula hdf5
-        brew update
         brew install --formula open-mpi
-        brew update
         brew install --formula gsl
-        brew update
         brew install --formula boost
-        brew update
         brew install --formula zlib
-        brew update
         . /opt/homebrew/bin/thisroot.sh
 
     - name: set environment variables

--- a/.github/workflows/test-build-macos-native.yaml
+++ b/.github/workflows/test-build-macos-native.yaml
@@ -1,0 +1,100 @@
+name: test build macOS native
+
+on:
+  pull_request:
+    branches:
+      - main
+      - JETSCAPE-4.0-RC
+      - latessa/gtl_binary_function
+  push:
+    branches:
+      - main
+      - JETSCAPE-4.0-RC
+      - latessa/gtl_binary_function
+
+env:
+  REPO_NAME: ${{ github.event.repository.name }}
+
+jobs:
+  build:
+    name: install packages and build
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [macos-14, macos-15]
+
+    steps:
+
+    - name: brew install dependencies
+      run: |
+        NONINTERACTIVE=1 brew install --formula cmake doxygen root graph-tool hdf5 open-mpi gsl boost zlib
+        . /opt/homebrew/bin/thisroot.sh
+
+    - name: set environment variables
+      run: |
+        export ROOTSYS="/usr/local/root"
+        export PATH="$ROOTSYS/bin:\$PATH"
+        export LD_LIBRARY_PATH="$ROOTSYS/lib:$LD_LIBRARY_PATH"
+        export PYTHONPATH="$ROOTSYS/lib"
+
+    - name: install HepMC 3.2.6
+      run: | # brew tap davidchall/hep
+        brew tap davidchall/homebrew-hep
+        cd $(brew --repository)/Library/Taps/davidchall/homebrew-hep
+        echo "Current directory: $(pwd)"
+        git checkout f643d5cacc19fd0b01d0ecba0daf30452152da03
+        NONINTERACTIVE=1 brew install davidchall/hep/hepmc3
+
+    - name: install Pythia 8309
+      run: |
+        cd $(brew --repository)/Library/Taps/davidchall/homebrew-hep
+        echo "Current directory: $(pwd)"
+        git checkout 141f8548d045df88d498ab44df16d2091742e4b1
+        NONINTERACTIVE=1 brew install davidchall/hep/pythia
+
+    - name: set more variables
+      run: |
+        export JETSCAPE_DIR="${GITHUB_WORKSPACE}/${REPO_NAME}"
+
+    - name: Checkout JETSCAPE Repository
+      uses: actions/checkout@v4
+      with:
+        path: ${{ github.event.repository.name }}
+
+    - name: Download MUSIC
+      run: |
+        cd ${GITHUB_WORKSPACE}/${REPO_NAME}/external_packages
+        ./get_music.sh
+
+    - name: Download ISS
+      run: |
+        cd ${GITHUB_WORKSPACE}/${REPO_NAME}/external_packages
+        ./get_iSS.sh
+
+    - name: Download FREESTREAM
+      run: |
+        cd ${GITHUB_WORKSPACE}/${REPO_NAME}/external_packages
+        ./get_freestream-milne.sh
+
+    - name: Download SMASH
+      run: |
+        export PYTHIA8DIR="/opt/homebrew/opt/pythia"
+        cd ${GITHUB_WORKSPACE}/${REPO_NAME}/external_packages
+        ./get_smash.sh
+
+    - name: Build Application
+      run: |
+        cd ${GITHUB_WORKSPACE}/${REPO_NAME}
+        mkdir build
+        cd build
+        export SMASH_DIR="${GITHUB_WORKSPACE}/${REPO_NAME}/external_packages/smash/smash_code"
+        echo "This is SMASH_DIR: "
+        echo ${SMASH_DIR}
+        ls ${SMASH_DIR}
+        cmake .. -DUSE_MUSIC=ON -DUSE_ISS=ON -DUSE_FREESTREAM=ON -DUSE_SMASH=ON
+        make -j2
+
+    - name: Test Run
+      run: |
+        cd ${GITHUB_WORKSPACE}/${REPO_NAME}/build
+        ./runJetscape ../config/publications_config/arXiv_1910.05481/jetscape_user_PP_1910.05481.xml

--- a/.github/workflows/test-build-macos-native.yaml
+++ b/.github/workflows/test-build-macos-native.yaml
@@ -30,6 +30,7 @@ jobs:
         export NONINTERACTIVE=1
         brew update
         brew cleanup
+        brew unlink pkg-config@0.29.2
         brew install --formula cmake
         brew update
         brew install --formula doxygen

--- a/.github/workflows/test-build-macos-native.yaml
+++ b/.github/workflows/test-build-macos-native.yaml
@@ -31,14 +31,23 @@ jobs:
         brew update
         brew cleanup
         brew install --formula cmake
+        brew update
         brew install --formula doxygen
+        brew update
         brew install --formula root
+        brew update
         brew install --formula graph-tool
+        brew update
         brew install --formula hdf5
+        brew update
         brew install --formula open-mpi
+        brew update
         brew install --formula gsl
+        brew update
         brew install --formula boost
+        brew update
         brew install --formula zlib
+        brew update
         . /opt/homebrew/bin/thisroot.sh
 
     - name: set environment variables

--- a/.github/workflows/test-build-macos-native.yaml
+++ b/.github/workflows/test-build-macos-native.yaml
@@ -27,7 +27,7 @@ jobs:
 
     - name: brew install dependencies
       run: |
-        NONINTERACTIVE=1 brew install --formula cmake doxygen root hdf5 open-mpi gsl boost zlib
+        NONINTERACTIVE=1 brew install --formula cmake doxygen root hdf5 open-mpi gsl boost
         . /opt/homebrew/bin/thisroot.sh
 
     - name: set environment variables

--- a/.github/workflows/test-build-macos-native.yaml
+++ b/.github/workflows/test-build-macos-native.yaml
@@ -25,15 +25,9 @@ jobs:
 
     steps:
 
-    - name: Set up Homebrew
-      run: |
-        brew update
-        brew install pkgconf
-        brew link --overwrite pkgconf
-
     - name: brew install dependencies
       run: |
-        NONINTERACTIVE=1 brew install --formula cmake doxygen root graph-tool hdf5 open-mpi gsl boost zlib
+        NONINTERACTIVE=1 brew install --formula cmake doxygen root hdf5 open-mpi gsl boost zlib
         . /opt/homebrew/bin/thisroot.sh
 
     - name: set environment variables

--- a/.github/workflows/test-build-macos-native.yaml
+++ b/.github/workflows/test-build-macos-native.yaml
@@ -27,7 +27,9 @@ jobs:
 
     - name: brew install dependencies
       run: |
-        NONINTERACTIVE=1 brew install --formula cmake doxygen root hdf5 open-mpi gsl boost
+        export NONINTERACTIVE=1
+        brew update
+        brew install --formula cmake doxygen root graph-tool hdf5 open-mpi gsl boost zlib
         . /opt/homebrew/bin/thisroot.sh
 
     - name: set environment variables

--- a/.github/workflows/test-build-macos-native.yaml
+++ b/.github/workflows/test-build-macos-native.yaml
@@ -29,7 +29,8 @@ jobs:
       run: |
         export NONINTERACTIVE=1
         brew update
-        brew install --formula cmake doxygen root graph-tool hdf5 open-mpi gsl boost
+        brew cleanup
+        brew install --formula cmake doxygen root graph-tool hdf5 open-mpi gsl boost zlib
         . /opt/homebrew/bin/thisroot.sh
 
     - name: set environment variables

--- a/.github/workflows/test-build-macos-native.yaml
+++ b/.github/workflows/test-build-macos-native.yaml
@@ -29,7 +29,7 @@ jobs:
       run: |
         export NONINTERACTIVE=1
         brew update
-        brew install --formula cmake doxygen root graph-tool hdf5 open-mpi gsl boost zlib
+        brew install --formula cmake doxygen root graph-tool hdf5 open-mpi gsl boost
         . /opt/homebrew/bin/thisroot.sh
 
     - name: set environment variables

--- a/.github/workflows/test-build-macos-native.yaml
+++ b/.github/workflows/test-build-macos-native.yaml
@@ -30,7 +30,15 @@ jobs:
         export NONINTERACTIVE=1
         brew update
         brew cleanup
-        brew install --formula cmake doxygen root graph-tool hdf5 open-mpi gsl boost zlib
+        brew install --formula cmake
+        brew install --formula doxygen
+        brew install --formula root
+        brew install --formula graph-tool
+        brew install --formula hdf5
+        brew install --formula open-mpi
+        brew install --formula gsl
+        brew install --formula boost
+        brew install --formula zlib
         . /opt/homebrew/bin/thisroot.sh
 
     - name: set environment variables

--- a/.github/workflows/test-events-PbPb.yaml
+++ b/.github/workflows/test-events-PbPb.yaml
@@ -4,12 +4,12 @@ on:
   pull_request:
     branches:
       - main
-      - JETSCAPE-4.0-RC
+      - JETSCAPE-3.6.6-RC
       - latessa/gtl_binary_function
   push:
     branches:
       - main
-      - JETSCAPE-4.0-RC
+      - JETSCAPE-3.6.6-RC
       - latessa/gtl_binary_function
 
 env:

--- a/.github/workflows/test-events-PbPb.yaml
+++ b/.github/workflows/test-events-PbPb.yaml
@@ -4,13 +4,13 @@ on:
   pull_request:
     branches:
       - main
-      - JETSCAPE-3.6.5-RC
-      - latessa/dockerImage
+      - JETSCAPE-4.0-RC
+      - latessa/gtl_binary_function
   push:
     branches:
       - main
-      - JETSCAPE-3.6.5-RC
-      - latessa/dockerImage
+      - JETSCAPE-4.0-RC
+      - latessa/gtl_binary_function
 
 env:
   REPO_NAME: ${{ github.event.repository.name }}

--- a/.github/workflows/test-events-brick.yaml
+++ b/.github/workflows/test-events-brick.yaml
@@ -5,13 +5,13 @@ on:
     branches:
       - main
       - brick_matter_lbt
-      - JETSCAPE-4.0-RC
+      - JETSCAPE-3.6.6-RC
       - latessa/gtl_binary_function
   push:
     branches:
       - main
       - brick_matter_lbt
-      - JETSCAPE-4.0-RC
+      - JETSCAPE-3.6.6-RC
       - latessa/gtl_binary_function
 
 env:

--- a/.github/workflows/test-events-brick.yaml
+++ b/.github/workflows/test-events-brick.yaml
@@ -4,15 +4,15 @@ on:
   pull_request:
     branches:
       - main
-      - JETSCAPE-3.6.5-RC
       - brick_matter_lbt
-      - latessa/dockerImage
+      - JETSCAPE-4.0-RC
+      - latessa/gtl_binary_function
   push:
     branches:
       - main
-      - JETSCAPE-3.6.5-RC
       - brick_matter_lbt
-      - latessa/dockerImage
+      - JETSCAPE-4.0-RC
+      - latessa/gtl_binary_function
 
 env:
   REPO_NAME: ${{ github.event.repository.name }}

--- a/.github/workflows/test-events-pp.yaml
+++ b/.github/workflows/test-events-pp.yaml
@@ -4,12 +4,12 @@ on:
   pull_request:
     branches:
       - main
-      - JETSCAPE-4.0-RC
+      - JETSCAPE-3.6.6-RC
       - latessa/gtl_binary_function
   push:
     branches:
       - main
-      - JETSCAPE-4.0-RC
+      - JETSCAPE-3.6.6-RC
       - latessa/gtl_binary_function
 
 env:

--- a/.github/workflows/test-events-pp.yaml
+++ b/.github/workflows/test-events-pp.yaml
@@ -4,13 +4,13 @@ on:
   pull_request:
     branches:
       - main
-      - JETSCAPE-3.6.5-RC
-      - latessa/dockerImage
+      - JETSCAPE-4.0-RC
+      - latessa/gtl_binary_function
   push:
     branches:
       - main
-      - JETSCAPE-3.6.5-RC
-      - latessa/dockerImage
+      - JETSCAPE-4.0-RC
+      - latessa/gtl_binary_function
 
 env:
   REPO_NAME: ${{ github.event.repository.name }}

--- a/external_packages/gtl/include/GTL/GTL.h
+++ b/external_packages/gtl/include/GTL/GTL.h
@@ -163,7 +163,6 @@ using std::stack;
 using std::map;
 using std::set;
 using std::allocator;
-using std::binary_function;
 using std::ostream;
 using std::ofstream;
 using std::cout;

--- a/external_packages/gtl/src/bid_dijkstra.cpp
+++ b/external_packages/gtl/src/bid_dijkstra.cpp
@@ -30,7 +30,7 @@ __GTL_BEGIN_NAMESPACE
  * @internal
  * Binary predicate that compares two nodes according to their distance.
  */
-class less_dist : public binary_function<node, node, bool>
+class less_dist
 {
 public:
     /**

--- a/external_packages/gtl/src/dijkstra.cpp
+++ b/external_packages/gtl/src/dijkstra.cpp
@@ -30,7 +30,7 @@ __GTL_BEGIN_NAMESPACE
  * @internal
  * Binary predicate that compares two nodes according to their distance.
  */
-class less_dist : public binary_function<node, node, bool>
+class less_dist
 {
 public:
     /**


### PR DESCRIPTION
This PR resolves the compilation issue when using Clang 16 by removing the binary_function inheritance in the GTL library.

GitHub Actions workflows are also added to test that JETSCAPE compiles on native Mac hardware.  Separate workflows use Clang 15 and Clang 16, so both compilers are verified.

https://github.com/JETSCAPE/JETSCAPE/actions/runs/11506333653

This test compiles JETSCAPE on native Mac runners with the external packages Music, iSS, Freestream, and Smash turned on.

runJetscape with [arXiv_1910.05481/jetscape_user_PP_1910.05481.xml](https://github.com/JETSCAPE/JETSCAPE/blob/main/config/publications_config/arXiv_1910.05481/jetscape_user_PP_1910.05481.xml) is then executed just to ensure that JETSCAPE runs and exits successfully.

Would it be preferred for the clang 16 GTL fix to be redirected to the JETSCAPE 4.0 release candidate, or would it be preferred for there to be a JETSCAPE 3.6.6 release?