### PR TITLE
GTL Modification and Native Mac Workflow

### DIFF
--- a/.github/workflows/test-build-external.yaml
+++ b/.github/workflows/test-build-external.yaml
@@ -5,10 +5,12 @@ on:
     branches:
       - main
       - JETSCAPE-4.0-RC
+      - latessa/gtl_binary_function_40
   push:
     branches:
       - main
       - JETSCAPE-4.0-RC
+      - latessa/gtl_binary_function_40
 
 env:
   REPO_NAME: ${{ github.event.repository.name }}

--- a/.github/workflows/test-build-macos-native.yaml
+++ b/.github/workflows/test-build-macos-native.yaml
@@ -1,0 +1,100 @@
+name: test build macOS native
+
+on:
+  pull_request:
+    branches:
+      - main
+      - JETSCAPE-4.0-RC
+      - latessa/gtl_binary_function_40
+  push:
+    branches:
+      - main
+      - JETSCAPE-4.0-RC
+      - latessa/gtl_binary_function_40
+
+env:
+  REPO_NAME: ${{ github.event.repository.name }}
+
+jobs:
+  build:
+    name: install packages and build
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [macos-14, macos-15]
+
+    steps:
+
+    - name: brew install dependencies
+      run: |
+        NONINTERACTIVE=1 brew install --formula cmake doxygen root graph-tool hdf5 open-mpi gsl boost zlib
+        . /opt/homebrew/bin/thisroot.sh
+
+    - name: set environment variables
+      run: |
+        export ROOTSYS="/usr/local/root"
+        export PATH="$ROOTSYS/bin:\$PATH"
+        export LD_LIBRARY_PATH="$ROOTSYS/lib:$LD_LIBRARY_PATH"
+        export PYTHONPATH="$ROOTSYS/lib"
+
+    - name: install HepMC 3.2.6
+      run: | # brew tap davidchall/hep
+        brew tap davidchall/homebrew-hep
+        cd $(brew --repository)/Library/Taps/davidchall/homebrew-hep
+        echo "Current directory: $(pwd)"
+        git checkout f643d5cacc19fd0b01d0ecba0daf30452152da03
+        NONINTERACTIVE=1 brew install davidchall/hep/hepmc3
+
+    - name: install Pythia 8309
+      run: |
+        cd $(brew --repository)/Library/Taps/davidchall/homebrew-hep
+        echo "Current directory: $(pwd)"
+        git checkout 141f8548d045df88d498ab44df16d2091742e4b1
+        NONINTERACTIVE=1 brew install davidchall/hep/pythia
+
+    - name: set more variables
+      run: |
+        export JETSCAPE_DIR="${GITHUB_WORKSPACE}/${REPO_NAME}"
+
+    - name: Checkout JETSCAPE Repository
+      uses: actions/checkout@v4
+      with:
+        path: ${{ github.event.repository.name }}
+
+    - name: Download MUSIC
+      run: |
+        cd ${GITHUB_WORKSPACE}/${REPO_NAME}/external_packages
+        ./get_music.sh
+
+    - name: Download ISS
+      run: |
+        cd ${GITHUB_WORKSPACE}/${REPO_NAME}/external_packages
+        ./get_iSS.sh
+
+    - name: Download FREESTREAM
+      run: |
+        cd ${GITHUB_WORKSPACE}/${REPO_NAME}/external_packages
+        ./get_freestream-milne.sh
+
+    - name: Download SMASH
+      run: |
+        export PYTHIA8DIR="/opt/homebrew/opt/pythia"
+        cd ${GITHUB_WORKSPACE}/${REPO_NAME}/external_packages
+        ./get_smash.sh
+
+    - name: Build Application
+      run: |
+        cd ${GITHUB_WORKSPACE}/${REPO_NAME}
+        mkdir build
+        cd build
+        export SMASH_DIR="${GITHUB_WORKSPACE}/${REPO_NAME}/external_packages/smash/smash_code"
+        echo "This is SMASH_DIR: "
+        echo ${SMASH_DIR}
+        ls ${SMASH_DIR}
+        cmake .. -DUSE_MUSIC=ON -DUSE_ISS=ON -DUSE_FREESTREAM=ON -DUSE_SMASH=ON
+        make -j2
+
+    - name: Test Run
+      run: |
+        cd ${GITHUB_WORKSPACE}/${REPO_NAME}/build
+        ./runJetscape ../config/publications_config/arXiv_1910.05481/jetscape_user_PP_1910.05481.xml

--- a/.github/workflows/test-build-macos-native.yaml
+++ b/.github/workflows/test-build-macos-native.yaml
@@ -29,6 +29,7 @@ jobs:
       run: |
         NONINTERACTIVE=1 brew install --formula cmake doxygen root graph-tool hdf5 open-mpi gsl boost zlib libomp
         . /opt/homebrew/bin/thisroot.sh
+        brew --prefix libomp
 
     - name: set environment variables
       run: |
@@ -36,7 +37,6 @@ jobs:
         export PATH="$ROOTSYS/bin:\$PATH"
         export LD_LIBRARY_PATH="$ROOTSYS/lib:$LD_LIBRARY_PATH"
         export PYTHONPATH="$ROOTSYS/lib"
-        brew --prefix libomp
         export OpenMP_INCLUDE_DIRS="/usr/local/opt/libomp/include"
 
     - name: install HepMC 3.2.6

--- a/.github/workflows/test-build-macos-native.yaml
+++ b/.github/workflows/test-build-macos-native.yaml
@@ -27,7 +27,7 @@ jobs:
 
     - name: brew install dependencies
       run: |
-        NONINTERACTIVE=1 brew install --formula cmake doxygen root graph-tool hdf5 open-mpi gsl boost zlib
+        NONINTERACTIVE=1 brew install --formula cmake doxygen root graph-tool hdf5 open-mpi gsl boost zlib libomp
         . /opt/homebrew/bin/thisroot.sh
 
     - name: set environment variables
@@ -36,7 +36,6 @@ jobs:
         export PATH="$ROOTSYS/bin:\$PATH"
         export LD_LIBRARY_PATH="$ROOTSYS/lib:$LD_LIBRARY_PATH"
         export PYTHONPATH="$ROOTSYS/lib"
-        echo "brew omp: "
         brew --prefix libomp
         export OpenMP_INCLUDE_DIRS="/usr/local/opt/libomp/include"
 

--- a/.github/workflows/test-build-macos-native.yaml
+++ b/.github/workflows/test-build-macos-native.yaml
@@ -37,9 +37,6 @@ jobs:
         export PATH="$ROOTSYS/bin:\$PATH"
         export LD_LIBRARY_PATH="$ROOTSYS/lib:$LD_LIBRARY_PATH"
         export PYTHONPATH="$ROOTSYS/lib"
-        export LDFLAGS="-L/opt/homebrew/opt/libomp/lib"
-        export CPPFLAGS="-I/opt/homebrew/opt/libomp/include"
-        export OpenMP_INCLUDE_DIRS="/opt/homebrew/opt/libomp/include"
 
     - name: install HepMC 3.2.6
       run: | # brew tap davidchall/hep
@@ -91,6 +88,7 @@ jobs:
         cd ${GITHUB_WORKSPACE}/${REPO_NAME}
         mkdir build
         cd build
+        export OpenMP_INCLUDE_DIRS="/opt/homebrew/opt/libomp/include"
         export SMASH_DIR="${GITHUB_WORKSPACE}/${REPO_NAME}/external_packages/smash/smash_code"
         echo "This is SMASH_DIR: "
         echo ${SMASH_DIR}

--- a/.github/workflows/test-build-macos-native.yaml
+++ b/.github/workflows/test-build-macos-native.yaml
@@ -36,6 +36,9 @@ jobs:
         export PATH="$ROOTSYS/bin:\$PATH"
         export LD_LIBRARY_PATH="$ROOTSYS/lib:$LD_LIBRARY_PATH"
         export PYTHONPATH="$ROOTSYS/lib"
+        echo "brew omp: "
+        brew --prefix libomp
+        export OpenMP_INCLUDE_DIRS="/usr/local/opt/libomp/include"
 
     - name: install HepMC 3.2.6
       run: | # brew tap davidchall/hep

--- a/.github/workflows/test-build-macos-native.yaml
+++ b/.github/workflows/test-build-macos-native.yaml
@@ -37,7 +37,9 @@ jobs:
         export PATH="$ROOTSYS/bin:\$PATH"
         export LD_LIBRARY_PATH="$ROOTSYS/lib:$LD_LIBRARY_PATH"
         export PYTHONPATH="$ROOTSYS/lib"
-        export OpenMP_INCLUDE_DIRS="/usr/local/opt/libomp/include"
+        export LDFLAGS="-L/opt/homebrew/opt/libomp/lib"
+        export CPPFLAGS="-I/opt/homebrew/opt/libomp/include"
+        export OpenMP_INCLUDE_DIRS="/opt/homebrew/opt/libomp/include"
 
     - name: install HepMC 3.2.6
       run: | # brew tap davidchall/hep

--- a/.github/workflows/test-code-format.yaml
+++ b/.github/workflows/test-code-format.yaml
@@ -5,10 +5,12 @@ on:
     branches:
       - main
       - JETSCAPE-4.0-RC
+      - latessa/gtl_binary_function_40
   push:
     branches:
       - main
       - JETSCAPE-4.0-RC
+      - latessa/gtl_binary_function_40
 
 env:
   REPO_NAME: ${{ github.event.repository.name }}

--- a/.github/workflows/test-events-PbPb.yaml
+++ b/.github/workflows/test-events-PbPb.yaml
@@ -5,10 +5,12 @@ on:
     branches:
       - main
       - JETSCAPE-4.0-RC
+      - latessa/gtl_binary_function_40
   push:
     branches:
       - main
       - JETSCAPE-4.0-RC
+      - latessa/gtl_binary_function_40
 
 env:
   REPO_NAME: ${{ github.event.repository.name }}

--- a/.github/workflows/test-events-brick.yaml
+++ b/.github/workflows/test-events-brick.yaml
@@ -5,10 +5,12 @@ on:
     branches:
       - main
       - JETSCAPE-4.0-RC
+      - latessa/gtl_binary_function_40
   push:
     branches:
       - main
       - JETSCAPE-4.0-RC
+      - latessa/gtl_binary_function_40
 env:
   REPO_NAME: ${{ github.event.repository.name }}
 

--- a/.github/workflows/test-events-pp.yaml
+++ b/.github/workflows/test-events-pp.yaml
@@ -5,10 +5,12 @@ on:
     branches:
       - main
       - JETSCAPE-4.0-RC
+      - latessa/gtl_binary_function_40
   push:
     branches:
       - main
       - JETSCAPE-4.0-RC
+      - latessa/gtl_binary_function_40
 
 env:
   REPO_NAME: ${{ github.event.repository.name }}

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -350,8 +350,8 @@ include_directories(./external_packages/hydro_from_external_file)
 include_directories(./external_packages/Random123)
 include_directories(./examples/)
 if(APPLE)
-  # set OpenMP_INCLUDE_DIRS to the path of the OpenMP headers
-  # for example: /usr/local/opt/libomp/include
+  # set OpenMP_INCLUDE_DIRS to the path of the OpenMP headers for example:
+  # /usr/local/opt/libomp/include
   include_directories($ENV{OpenMP_INCLUDE_DIRS})
 endif()
 if("${ROOT_FOUND}")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -96,6 +96,11 @@ if(USE_SMASH)
 endif(USE_SMASH)
 
 # Compile with OpenMP support
+if(APPLE)
+  set(OpenMP_CXX_FLAGS "-Xpreprocessor -fopenmp")
+  set(OpenMP_CXX_LIB_NAMES "libomp")
+  set(OpenMP_libomp_LIBRARY "/usr/local/opt/libomp/lib")
+endif()
 find_package(OpenMP)
 if(OPENMP_FOUND)
   set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} ${OpenMP_C_FLAGS}")
@@ -344,6 +349,11 @@ include_directories(./external_packages/gtl/include)
 include_directories(./external_packages/hydro_from_external_file)
 include_directories(./external_packages/Random123)
 include_directories(./examples/)
+if(APPLE)
+  # set OpenMP_INCLUDE_DIRS to the path of the OpenMP headers
+  # for example: /usr/local/opt/libomp/include
+  include_directories($ENV{OpenMP_INCLUDE_DIRS})
+endif()
 if("${ROOT_FOUND}")
   include_directories(./src/root)
   # add_subdirectory(./src/root)

--- a/external_packages/gtl/include/GTL/GTL.h
+++ b/external_packages/gtl/include/GTL/GTL.h
@@ -163,7 +163,6 @@ using std::stack;
 using std::map;
 using std::set;
 using std::allocator;
-using std::binary_function;
 using std::ostream;
 using std::ofstream;
 using std::cout;

--- a/external_packages/gtl/src/bid_dijkstra.cpp
+++ b/external_packages/gtl/src/bid_dijkstra.cpp
@@ -30,7 +30,7 @@ __GTL_BEGIN_NAMESPACE
  * @internal
  * Binary predicate that compares two nodes according to their distance.
  */
-class less_dist : public binary_function<node, node, bool>
+class less_dist
 {
 public:
     /**

--- a/external_packages/gtl/src/dijkstra.cpp
+++ b/external_packages/gtl/src/dijkstra.cpp
@@ -30,7 +30,7 @@ __GTL_BEGIN_NAMESPACE
  * @internal
  * Binary predicate that compares two nodes according to their distance.
  */
-class less_dist : public binary_function<node, node, bool>
+class less_dist
 {
 public:
     /**


### PR DESCRIPTION
This PR applies the GTL modification to the JETSCAPE 4.0 release candidate branch, and adds a GitHub Actions workflow to test the installation on native Mac runners using Clang 15 and Clang 16.

This PR replaces PR #234, which was directed to the 3.6.5 main branch.  For this PR, which is directed to the 4.0 release candidate, CMakeLists was modified so Clang can find OpenMP, which is needed for ThermalPartonSampler in the 4.0 release candidate.
