### PR TITLE
Fix density rotation bug / FS automatic parameter determination

### DIFF
--- a/config/jetscape_main.xml
+++ b/config/jetscape_main.xml
@@ -285,6 +285,9 @@
       <!-- (only works for VISHNew evo files) -->
       <load_viscous_info>0</load_viscous_info>
 
+      <!-- PreEquilibrium evolution filename (plain binary format) -->
+      <PreEq_file>../examples/test_hydro_files/evolution_all_xyeta_fs.dat</PreEq_file>
+
       <!-- MUSIC hydro evolution filename (plain binary format) -->
       <!-- the associated input file specifies the grid information -->
       <MUSIC_input_file>../examples/test_hydro_files/MUSIC_input</MUSIC_input_file>

--- a/config/jetscape_main.xml
+++ b/config/jetscape_main.xml
@@ -222,6 +222,9 @@
     <FreestreamMilne>
       <name>FreestreamMilne</name>
       <freestream_input_file>freestream_input</freestream_input_file>
+      <!-- number of timesteps for the evolution, this defines the dtau = (taus - tauj)  / ntau -->
+      <!-- in the case of <evolutionInMemory>1</evolutionInMemory> this will also set the time step for the hydro, make sure that it is small enough -->
+      <ntau>50</ntau>
     </FreestreamMilne>
 
     <NullPreDynamics> </NullPreDynamics>

--- a/external_packages/get_freestream-milne.sh
+++ b/external_packages/get_freestream-milne.sh
@@ -18,11 +18,13 @@
 #git clone --depth=1 https://github.com/derekeverett/freestream-milne.git -b time_step_history freestream-milne
 #git clone --depth=1 https://github.com/chunshen1987/freestream-milne -b time_step_history freestream-milne
 
-# using a commit from the freestream-milne repository that is compatible with JETSCAPE 3.6.1
+# using a commit from the freestream-milne repository that is compatible with JETSCAPE 3.6.6
 folderName="freestream-milne"
-commitHash="94722958595cb712fdb00cc59375ad7c9030faed"
+#commitHash="94722958595cb712fdb00cc59375ad7c9030faed"
+commitHash="0d980593396a8b2f6a9b3933780215df00022d58"
 
-git clone https://github.com/chunshen1987/freestream-milne -b time_step_history $folderName
+#git clone https://github.com/chunshen1987/freestream-milne -b time_step_history $folderName
+git clone https://github.com/chunshen1987/freestream-milne -b fix_output_orientation $folderName
 cd $folderName
 git checkout $commitHash
 

--- a/external_packages/get_freestream-milne.sh
+++ b/external_packages/get_freestream-milne.sh
@@ -20,7 +20,7 @@
 
 # using a commit from the freestream-milne repository that is compatible with JETSCAPE 3.6.6
 folderName="freestream-milne"
-commitHash="caaa3b82158c372a42599e1acd6917952b9bdfb6"
+commitHash="e0a21feb48a922b4b4541ab0e4d745c65594bb5f"
 
 git clone https://github.com/chunshen1987/freestream-milne -b time_step_history $folderName
 cd $folderName

--- a/external_packages/get_freestream-milne.sh
+++ b/external_packages/get_freestream-milne.sh
@@ -20,11 +20,9 @@
 
 # using a commit from the freestream-milne repository that is compatible with JETSCAPE 3.6.6
 folderName="freestream-milne"
-#commitHash="94722958595cb712fdb00cc59375ad7c9030faed"
-commitHash="0d980593396a8b2f6a9b3933780215df00022d58"
+commitHash="caaa3b82158c372a42599e1acd6917952b9bdfb6"
 
-#git clone https://github.com/chunshen1987/freestream-milne -b time_step_history $folderName
-git clone https://github.com/chunshen1987/freestream-milne -b fix_output_orientation $folderName
+git clone https://github.com/chunshen1987/freestream-milne -b time_step_history $folderName
 cd $folderName
 git checkout $commitHash
 

--- a/external_packages/get_music.sh
+++ b/external_packages/get_music.sh
@@ -20,7 +20,7 @@
 
 # using a commit from the MUSIC repository that is compatible with JETSCAPE 3.6.6
 folderName="music"
-commitHash="567212026e85b409458db68a2d3b13cc89fa49a1"
+commitHash="fdcce5d9f63fc25281eda8d498c32c69ac132dac"
 
 git clone https://github.com/MUSIC-fluid/MUSIC -b JETSCAPE $folderName
 cd $folderName

--- a/src/preequilibrium/FreestreamMilneWrapper.cc
+++ b/src/preequilibrium/FreestreamMilneWrapper.cc
@@ -85,7 +85,7 @@ void FreestreamMilneWrapper::InitializePreequilibrium(
   params->DETA = deta;
 
   //setting for the number of time steps
-  int ntau = GetXMLElementInt({"Preequilibrium", "ntau"});
+  int ntau = GetXMLElementInt({"Preequilibrium", "FreestreamMilne", "ntau"});
   params->NT = ntau;
 }
 

--- a/src/preequilibrium/FreestreamMilneWrapper.cc
+++ b/src/preequilibrium/FreestreamMilneWrapper.cc
@@ -67,6 +67,22 @@ void FreestreamMilneWrapper::InitializePreequilibrium(
   params->TAUJ = tauj;
   params->DTAU = taus - tau0;
   params->evolutionInMemory = FlagEvo;
+
+  //settings for the grid size
+  int nx = ini->GetXSize();
+  int ny = ini->GetYSize();
+  int neta = ini->GetZSize();
+  params->DIM_X = nx;
+  params->DIM_Y = ny;
+  params->DIM_ETA = neta;
+
+  //settings for the grid step size
+  double dx = ini->GetXStep();
+  double dy = ini->GetYStep();
+  double deta = ini->GetZStep();
+  params->DX = dx;
+  params->DY = dy;
+  params->DETA = deta;
 }
 
 void FreestreamMilneWrapper::EvolvePreequilibrium() {

--- a/src/preequilibrium/FreestreamMilneWrapper.cc
+++ b/src/preequilibrium/FreestreamMilneWrapper.cc
@@ -83,6 +83,10 @@ void FreestreamMilneWrapper::InitializePreequilibrium(
   params->DX = dx;
   params->DY = dy;
   params->DETA = deta;
+
+  //setting for the number of time steps
+  int ntau = GetXMLElementInt({"Preequilibrium", "ntau"});
+  params->NT = ntau;
 }
 
 void FreestreamMilneWrapper::EvolvePreequilibrium() {


### PR DESCRIPTION
This closes #236 and it also implements the automatic determination of grid parameters for the free streaming module from the initial state module. The user can now use the `ntau` key in the XML file to determine the time steps in the free streaming phase.

@chunshen1987 This has to be tested. @ritobandatta will run a few more tests.