### PR TITLE
Add option to filter on status code for final state hadrons

### DIFF
--- a/config/jetscape_main.xml
+++ b/config/jetscape_main.xml
@@ -39,6 +39,14 @@
   <QnVector_Nrap>80</QnVector_Nrap>
   <QnVector_Norder>7</QnVector_Norder>
   <write_pthat> 0 </write_pthat>
+  <Writer>
+    <FinalStateHadrons>
+      <statusToSkip></statusToSkip>
+    </FinalStateHadrons>
+    <FinalStatePartons>
+      <statusToSkip></statusToSkip>
+    </FinalStatePartons>
+  </Writer>
 
   <!--  Random Settings. For now, just a global  seed. -->
   <!--  Note: It's each modules responsibility to adopt it -->

--- a/examples/FinalStateHadrons.cc
+++ b/examples/FinalStateHadrons.cc
@@ -53,7 +53,7 @@ int main(int argc, char** argv)
   // Default: version 1.
   int headerVersion = 1;
   if (argc > 3) {
-    headerVersion = static_cast<int>(argv[3]);
+    headerVersion = std::atoi(argv[3]);
   }
   std::cout << "NOTE: Writing with output version v" << headerVersion << "\n";
 

--- a/examples/FinalStateHadrons.cc
+++ b/examples/FinalStateHadrons.cc
@@ -41,25 +41,24 @@ using namespace Jetscape;
 
 int main(int argc, char** argv)
 {
-
   // JetScapeLogger::Instance()->SetInfo(false);
   JetScapeLogger::Instance()->SetDebug(false);
   JetScapeLogger::Instance()->SetRemark(false);
   // //SetVerboseLevel (9 a lot of additional debug output ...)
-  // //If you want to suppress it: use SetVerboseLevle(0) or max  SetVerboseLevel(9) or 10
+  // //If you want to suppress it: use SetVerboseLevel(0) or max  SetVerboseLevel(9) or 10
   JetScapeLogger::Instance()->SetVerboseLevel(0);
 
   // Whether to write the new header (ie. v2), including xsec info.
   // To enable, pass anything as the third argument to enable this option.
-  // Default: disabled.
-  bool writeHeaderV2 = false;
+  // Default: version 1.
+  int headerVersion = 1;
   if (argc > 3) {
-    writeHeaderV2 = static_cast<bool>(argv[3]);
-    std::cout << "NOTE: Writing header v2, and final cross section and error at EOF.\n";
+    headerVersion = static_cast<int>(argv[3]);
   }
+  std::cout << "NOTE: Writing with output version v" << headerVersion << "\n";
 
-  // The seperator between particles _does not_ depend on the header for final state hadrons
-  std::string particleSeperator = " ";
+  // The separator between particles _does not_ depend on the header for final state hadrons
+  std::string particleSeparator = " ";
 
   auto reader = make_shared<JetScapeReaderAscii>(argv[1]);
   std::ofstream dist_output (argv[2]); //Format is SN, PID, E, Px, Py, Pz, Eta, Phi
@@ -78,7 +77,7 @@ int main(int argc, char** argv)
     if (hadrons.size() > 0)
     {
       ++SN;
-      if (writeHeaderV2) {
+      if (headerVersion == 2) {
         // NOTE: Needs consistent "\t" between all entries to simplify parsing later.
         dist_output << "#"
             << "\t" << "Event\t" << SN
@@ -110,17 +109,17 @@ int main(int argc, char** argv)
       for (unsigned int i=0; i<hadrons.size(); i++)
       {
         dist_output << i
-            << particleSeperator << hadrons[i].get()->pid()
-            << particleSeperator << hadrons[i].get()->pstat()
-            << particleSeperator << hadrons[i].get()->e()
-            << particleSeperator << hadrons[i].get()->px()
-            << particleSeperator << hadrons[i].get()->py()
-            << particleSeperator << hadrons[i].get()->pz();
+            << particleSeparator << hadrons[i].get()->pid()
+            << particleSeparator << hadrons[i].get()->pstat()
+            << particleSeparator << hadrons[i].get()->e()
+            << particleSeparator << hadrons[i].get()->px()
+            << particleSeparator << hadrons[i].get()->py()
+            << particleSeparator << hadrons[i].get()->pz();
 
         // v2 drops eta and phi, so only include it for v1
-        if (!writeHeaderV2) {
-            dist_output << particleSeperator << hadrons[i].get()->eta()
-                << particleSeperator << hadrons[i].get()->phi();
+        if (headerVersion == 1) {
+            dist_output << particleSeparator << hadrons[i].get()->eta()
+                << particleSeparator << hadrons[i].get()->phi();
         }
 
         // Finish up
@@ -129,7 +128,7 @@ int main(int argc, char** argv)
     }
   }
   // Write the final cross section and error if requested by using header v2
-  if (writeHeaderV2) {
+  if (headerVersion > 1) {
     // NOTE: Needs consistent "\t" between all entries to simplify parsing later.
     dist_output << "#"
         << "\t" << "sigmaGen\t" << reader->GetSigmaGen()

--- a/examples/FinalStatePartons.cc
+++ b/examples/FinalStatePartons.cc
@@ -51,17 +51,17 @@ int main(int argc, char** argv)
 
   // Whether to write the new header (ie. v2), including xsec info.
   // To enable, pass anything as the third argument to enable this option.
-  // Default: disabled.
-  bool writeHeaderV2 = false;
+  // Default: version 1.
+  int headerVersion = 1;
   if (argc > 3) {
-    writeHeaderV2 = static_cast<bool>(argv[3]);
-    std::cout << "NOTE: Writing header v2, and final cross section and error at EOF.\n";
+    headerVersion = static_cast<int>(argv[3]);
   }
+  std::cout << "NOTE: Writing with output version v" << headerVersion << "\n";
 
-  // The seperator between particles depends on the header.
-  std::string particleSeperator = " ";
-  if (!writeHeaderV2) {
-    particleSeperator = "\t";
+  // The separator between particles depends on the header.
+  std::string particleSeparator = " ";
+  if (headerVersion == 1) {
+    particleSeparator = "\t";
   }
 
   auto reader=make_shared<JetScapeReaderAscii>(argv[1]);
@@ -83,7 +83,7 @@ int main(int argc, char** argv)
     if(TotalPartons > 0)
     {
       ++SN;
-      if (writeHeaderV2) {
+      if (headerVersion == 2) {
         // NOTE: Needs consistent "\t" between all entries to simplify parsing later.
         dist_output << "#"
             << "\t" << "Event\t" << SN
@@ -122,17 +122,17 @@ int main(int argc, char** argv)
           //            if(abs(p.pid())!=5) continue;
 
           dist_output << ipart
-              << particleSeperator << p.pid()
-              << particleSeperator << p.pstat()
-              << particleSeperator << p.e()
-              << particleSeperator << p.px()
-              << particleSeperator << p.py()
-              << particleSeperator << p.pz();
+              << particleSeparator << p.pid()
+              << particleSeparator << p.pstat()
+              << particleSeparator << p.e()
+              << particleSeparator << p.px()
+              << particleSeparator << p.py()
+              << particleSeparator << p.pz();
 
           // v2 drops eta and phi, so only include it for v1
-          if (!writeHeaderV2) {
-              dist_output << particleSeperator << p.eta()
-                  << particleSeperator << p.phi();
+          if (headerVersion == 1) {
+              dist_output << particleSeparator << p.eta()
+                  << particleSeparator << p.phi();
           }
 
           // Finish up
@@ -142,7 +142,7 @@ int main(int argc, char** argv)
     }
   }
   // Write the final cross section and error if requested by using header v2
-  if (writeHeaderV2) {
+  if (headerVersion > 1) {
     // NOTE: Needs consistent "\t" between all entries to simplify parsing later.
     dist_output << "#"
         << "\t" << "sigmaGen\t" << reader->GetSigmaGen()

--- a/examples/FinalStatePartons.cc
+++ b/examples/FinalStatePartons.cc
@@ -54,7 +54,7 @@ int main(int argc, char** argv)
   // Default: version 1.
   int headerVersion = 1;
   if (argc > 3) {
-    headerVersion = static_cast<int>(argv[3]);
+    headerVersion = std::atoi(argv[3]);
   }
   std::cout << "NOTE: Writing with output version v" << headerVersion << "\n";
 

--- a/src/framework/JetScapeWriterFinalStateStream.cc
+++ b/src/framework/JetScapeWriterFinalStateStream.cc
@@ -75,27 +75,6 @@ template <class T> JetScapeWriterFinalStateStream<T>::~JetScapeWriterFinalStateS
     Close();
 }
 
-template <class T> JetScapeWriterFinalStateStream<T>::Init() {
-  // Whether to write the pt hat value for each event
-  writePtHat = static_cast<bool>(JetScapeXML::Instance()->GetElementInt({"write_pthat"}));
-
-  // Status codes to filter out from what is written (i.e. to be skipped)
-  std::string s = JetScapeXML::Instance()->GetXMLElementText({"Writer", std::string("FinalState") + GetName(), "statusToSkip"}, false);
-  if (s.size() > 0) {
-    particleStatusToSkip = detail::stringToVector(s);
-    if (particleStatusToSkip.size() > 0) {
-      std::stringstream ss;
-      ss << "Skipping particles with status codes: ";
-      // Print the status codes that will be skipped for logging purposes to ensure that
-      // the values are propagated correctly.
-      for (const auto status : particleStatusToSkip) {
-        ss << status << " ";
-      }
-      JSINFO << ss.str();
-    }
-  }
-}
-
 template <class T> void JetScapeWriterFinalStateStream<T>::WriteEvent() {
   // Write the entire event all at once.
 
@@ -144,6 +123,14 @@ template <class T> void JetScapeWriterFinalStateStream<T>::WriteEvent() {
 }
 
 template <class T> void JetScapeWriterFinalStateStream<T>::Init() {
+  // Whether to write the pt hat value for each event
+  writePtHat = static_cast<bool>(JetScapeXML::Instance()->GetElementInt({"write_pthat"}));
+
+  // Status codes to filter out from what is written (i.e. to be skipped)
+  std::string s = JetScapeXML::Instance()->GetElementText({"Writer", std::string("FinalState") + GetName(), "statusToSkip"}, false);
+  if (s.size() > 0) {
+    particleStatusToSkip = detail::stringToVector(s);
+  }
   if (GetActive()) {
     // Capitalize name
     std::string name = GetName();
@@ -165,6 +152,17 @@ template <class T> void JetScapeWriterFinalStateStream<T>::Init() {
         << "\t" << "Py"
         << "\t" << "Pz"
         << "\n";
+
+    // Print the status codes that will be skipped for logging purposes to ensure that
+    // it's clear that the values are propagated correctly.
+    if (particleStatusToSkip.size() > 0) {
+      std::stringstream ss;
+      ss << "Skipping particles with status codes: ";
+      for (const auto status : particleStatusToSkip) {
+        ss << status << " ";
+      }
+      JSINFO << ss.str();
+    }
   }
 }
 
@@ -184,7 +182,7 @@ void JetScapeWriterFinalStateStream<T>::Write(weak_ptr<PartonShower> ps) {
   auto finalStatePartons = pShower->GetFinalPartons();
 
   // Store final state partons.
-  for (const auto parton : finalStatePartons) {
+  for (const auto & parton : finalStatePartons) {
       particles.push_back(parton);
   }
 }

--- a/src/framework/JetScapeWriterFinalStateStream.cc
+++ b/src/framework/JetScapeWriterFinalStateStream.cc
@@ -127,7 +127,7 @@ template <class T> void JetScapeWriterFinalStateStream<T>::Init() {
   writePtHat = static_cast<bool>(JetScapeXML::Instance()->GetElementInt({"write_pthat"}));
 
   // Status codes to filter out from what is written (i.e. to be skipped)
-  std::string s = JetScapeXML::Instance()->GetElementText({"Writer", std::string("FinalState") + GetName(), "statusToSkip"}, false);
+  std::string s = JetScapeXML::Instance()->GetElementText({"Writer", (std::string("FinalState") + GetName()).c_str(), "statusToSkip"}, false);
   if (s.size() > 0) {
     particleStatusToSkip = detail::stringToVector(s);
   }

--- a/src/framework/JetScapeWriterFinalStateStream.cc
+++ b/src/framework/JetScapeWriterFinalStateStream.cc
@@ -83,6 +83,16 @@ template <class T> JetScapeWriterFinalStateStream<T>::Init() {
   std::string s = JetScapeXML::Instance()->GetXMLElementText({"Writer", std::string("FinalState") + GetName(), "statusToSkip"}, false);
   if (s.size() > 0) {
     particleStatusToSkip = detail::stringToVector(s);
+    if (particleStatusToSkip.size() > 0) {
+      std::stringstream ss;
+      ss << "Skipping particles with status codes: ";
+      // Print the status codes that will be skipped for logging purposes to ensure that
+      // the values are propagated correctly.
+      for (const auto status : particleStatusToSkip) {
+        ss << status << " ";
+      }
+      JSINFO << ss.str();
+    }
   }
 }
 

--- a/src/framework/JetScapeWriterFinalStateStream.h
+++ b/src/framework/JetScapeWriterFinalStateStream.h
@@ -13,9 +13,9 @@
  * See COPYING for details.
  ******************************************************************************/
 
-// Jetscape final state {hadrons,kartons} writer ascii class
+// Jetscape final state {hadrons,partons} writer ascii class
 // Based on JetScapeWriterStream.
-// author: Raymond Ehlers <raymond.ehlers@cern.ch>, ORNL
+// author: Raymond Ehlers <raymond.ehlers@cern.ch>, LBL/UCB
 
 #ifndef JETSCAPEWRITERSTREAM_H
 #define JETSCAPEWRITERSTREAM_H
@@ -65,6 +65,8 @@ public:
 protected:
   T output_file; //!< Output file
   std::vector<std::shared_ptr<JetScapeParticleBase>> particles;
+  bool writePtHat;
+  std::vector<int> particleStatusToSkip;
 };
 
 template <class T>
@@ -81,7 +83,7 @@ protected:
 template <class T>
 class JetScapeWriterFinalStateHadronsStream : public JetScapeWriterFinalStateStream<T> {
   std::string GetName() { return "hadrons"; }
-  // Don't collect the hadrons by making it a no-op
+  // Don't collect the partons by making it a no-op
   void Write(weak_ptr<PartonShower> ps) { }
 protected:
   // Allows the registration of the module so that it is available to be used by the Jetscape framework.


### PR DESCRIPTION
Add optional ability to filter on the status code for the particles written in the final state {hadron,parton} readers.

NOTE: This also contains a separate fix from Chun, so that needs to be merged/removed first. It's currently being tested, and then this PR will be updated and changed from draft -> ready