### PR TITLE
pass net bayon density

### DIFF
--- a/src/framework/SurfaceCellInfo.h
+++ b/src/framework/SurfaceCellInfo.h
@@ -33,6 +33,7 @@ public:
   Jetscape::real entropy_density; //!< Local entropy density [1/fm^3].
   Jetscape::real temperature;     //!< Local temperature [GeV].
   Jetscape::real pressure;        //!< Thermal pressure [GeV/fm^3].
+  Jetscape::real baryon_density;  //!< net baryon density [1/fm^3].
   Jetscape::real
       qgp_fraction; //!< Fraction of quark gluon plasma assuming medium is in QGP+HRG phase.
   Jetscape::real mu_B;       //!< Net baryon chemical potential [GeV].

--- a/src/hadronization/iSpectraSamplerWrapper.cc
+++ b/src/hadronization/iSpectraSamplerWrapper.cc
@@ -253,6 +253,7 @@ int iSpectraSamplerWrapper::getSurfCellVector() {
     iSS_surf_cell.Edec = surf_i.energy_density;
     iSS_surf_cell.Tdec = surf_i.temperature;
     iSS_surf_cell.Pdec = surf_i.pressure;
+    iSS_surf_cell.Bn = surf_i.baryon_density;
     iSS_surf_cell.muB = surf_i.mu_B;
     iSS_surf_cell.muQ = surf_i.mu_Q;
     iSS_surf_cell.muS = surf_i.mu_S;

--- a/src/hydro/MusicWrapper.cc
+++ b/src/hydro/MusicWrapper.cc
@@ -405,6 +405,7 @@ void MpiMusic::PassHydroSurfaceToFramework() {
         surface_cell_info.energy_density = surfaceCell_i.energy_density;
         surface_cell_info.temperature = surfaceCell_i.temperature;
         surface_cell_info.pressure = surfaceCell_i.pressure;
+        surface_cell_info.baryon_density = surfaceCell_i.rho_b;
         surface_cell_info.mu_B = surfaceCell_i.mu_B;
         surface_cell_info.mu_Q = surfaceCell_i.mu_Q;
         surface_cell_info.mu_S = surfaceCell_i.mu_S;


### PR DESCRIPTION
iSS needs nB on hydro surface. The data structure in JETSCAPE does not contain this information. I modified the surface cell structure and pass this information from MUSIC to iSS via the wrappers.