### PR TITLE
update C++17 requirement CMakeLists syntax

### DIFF
--- a/.github/workflows/test-build-external.yaml
+++ b/.github/workflows/test-build-external.yaml
@@ -5,12 +5,12 @@ on:
     branches:
       - main
       - JETSCAPE-3.6.7-RC
-      - latessa/gtl_binary_function
+      - cpp17_cmake_syntax
   push:
     branches:
       - main
       - JETSCAPE-3.6.7-RC
-      - latessa/gtl_binary_function
+      - cpp17_cmake_syntax
 
 env:
   REPO_NAME: ${{ github.event.repository.name }}

--- a/.github/workflows/test-build-macos-native.yaml
+++ b/.github/workflows/test-build-macos-native.yaml
@@ -5,12 +5,12 @@ on:
     branches:
       - main
       - JETSCAPE-3.6.7-RC
-      - latessa/gtl_binary_function
+      - cpp17_cmake_syntax
   push:
     branches:
       - main
       - JETSCAPE-3.6.7-RC
-      - latessa/gtl_binary_function
+      - cpp17_cmake_syntax
 
 env:
   REPO_NAME: ${{ github.event.repository.name }}
@@ -102,7 +102,7 @@ jobs:
         echo "This is SMASH_DIR: "
         echo ${SMASH_DIR}
         ls ${SMASH_DIR}
-        cmake .. -DUSE_MUSIC=ON -DUSE_ISS=ON -DUSE_FREESTREAM=ON -DUSE_SMASH=ON -DCMAKE_CXX_STANDARD=17
+        cmake .. -DUSE_MUSIC=ON -DUSE_ISS=ON -DUSE_FREESTREAM=ON -DUSE_SMASH=ON
         make -j2
 
     - name: Test Run

--- a/.github/workflows/test-events-PbPb.yaml
+++ b/.github/workflows/test-events-PbPb.yaml
@@ -5,12 +5,12 @@ on:
     branches:
       - main
       - JETSCAPE-3.6.7-RC
-      - latessa/gtl_binary_function
+      - cpp17_cmake_syntax
   push:
     branches:
       - main
       - JETSCAPE-3.6.7-RC
-      - latessa/gtl_binary_function
+      - cpp17_cmake_syntax
 
 env:
   REPO_NAME: ${{ github.event.repository.name }}

--- a/.github/workflows/test-events-brick.yaml
+++ b/.github/workflows/test-events-brick.yaml
@@ -6,13 +6,13 @@ on:
       - main
       - brick_matter_lbt
       - JETSCAPE-3.6.7-RC
-      - latessa/gtl_binary_function
+      - cpp17_cmake_syntax
   push:
     branches:
       - main
       - brick_matter_lbt
       - JETSCAPE-3.6.7-RC
-      - latessa/gtl_binary_function
+      - cpp17_cmake_syntax
 
 env:
   REPO_NAME: ${{ github.event.repository.name }}

--- a/.github/workflows/test-events-pp.yaml
+++ b/.github/workflows/test-events-pp.yaml
@@ -5,12 +5,12 @@ on:
     branches:
       - main
       - JETSCAPE-3.6.7-RC
-      - latessa/gtl_binary_function
+      - cpp17_cmake_syntax
   push:
     branches:
       - main
       - JETSCAPE-3.6.7-RC
-      - latessa/gtl_binary_function
+      - cpp17_cmake_syntax
 
 env:
   REPO_NAME: ${{ github.event.repository.name }}

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -93,7 +93,9 @@ endif (USE_SMASH)
 ### Compiler & Linker Flags ###
 ###############################
 message("Compiler and Linker flags ...")
-set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fPIC -pipe -Wall -std=c++17")
+set(CMAKE_CXX_STANDARD 17)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fPIC -pipe -Wall")
 ## can turn off some warnings
 set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-reorder -Wno-unused-variable ")
 ## Then set the build type specific options. These will be automatically appended.


### PR DESCRIPTION
This modernizes the CMakeLists syntax requiring C++17 so it will work on newer compilers.