### PR TITLE
Additional free streaming parameters in XML

### DIFF
--- a/config/jetscape_main.xml
+++ b/config/jetscape_main.xml
@@ -227,6 +227,7 @@
       <ntau>50</ntau>
 
       <!--Energy dependent free streaming time (Phys.Rev.C 103 (2021) 5, 054904, see Eq. 19)-->
+      <!--This overrides the constant free streaming time defined by taus-->
       <!--E_DEP_FS = 0: constant free streaming time according to taus, E_DEP_FS = 1: energy dependent free streaming time-->
       <E_DEP_FS>0</E_DEP_FS>
       <!--E_R: energy scale in GeV/fm^2 for the energy dependent free streaming time-->

--- a/config/jetscape_main.xml
+++ b/config/jetscape_main.xml
@@ -44,7 +44,7 @@
   <!--  Note: It's each modules responsibility to adopt it -->
   <!--  Note: Most if not all modules should understand 0 to mean a random value -->
   <!--  Note: Both 0 and non-zero values require careful treatment in case of multi-threading -->
-  <!--           An example implementation is in JetEnergyLossManager.cc -->
+  <!--  An example implementation is in JetEnergyLossManager.cc -->
   <Random>
     <seed>0</seed>
   </Random>
@@ -212,10 +212,10 @@
 
     <!-- starting long. proper time for Preequilibrium dynamics -->
     <tau0>0.0</tau0>
-    <!-- starting long. proper time for Preequilibrium dynamics outuput for hard probes -->
+    <!-- starting long. proper time for Preequilibrium dynamics output for hard probes -->
     <tauj>0.1</tauj>
     <!-- switching long. proper time from Preequilibrium dynamics to Hydrodynamics (Landau Matching) -->
-    <taus>0.2</taus>
+    <taus>0.5</taus>
     <evolutionInMemory>1</evolutionInMemory>
 
     <!-- Individual Preequilibrium Dynamics models  -->
@@ -225,6 +225,16 @@
       <!-- number of timesteps for the evolution, this defines the dtau = (taus - tauj)  / ntau -->
       <!-- in the case of <evolutionInMemory>1</evolutionInMemory> this will also set the time step for the hydro, make sure that it is small enough -->
       <ntau>50</ntau>
+
+      <!--Energy dependent free streaming time (Phys.Rev.C 103 (2021) 5, 054904, see Eq. 19)-->
+      <!--E_DEP_FS = 0: constant free streaming time according to taus, E_DEP_FS = 1: energy dependent free streaming time-->
+      <E_DEP_FS>0</E_DEP_FS>
+      <!--E_R: energy scale in GeV/fm^2 for the energy dependent free streaming time-->
+      <E_R>4.0</E_R>
+      <!--TAU_R: free streaming time tau_R in fm for the energy dependent free streaming time-->
+      <TAU_R>1.46</TAU_R>
+      <!--ALPHA: power of the energy dependence for the energy dependent free streaming time-->
+      <ALPHA>0.031</ALPHA>
     </FreestreamMilne>
 
     <NullPreDynamics> </NullPreDynamics>

--- a/config/publications_config/arXiv_2011.01430/jetscape_user_AA_2011.01430.xml
+++ b/config/publications_config/arXiv_2011.01430/jetscape_user_AA_2011.01430.xml
@@ -64,8 +64,9 @@
 
         <!-- Individual Preequilibrium Dynamics models  -->
         <FreestreamMilne>
-            <name>FreestreamMilne</name>
-        <freestream_input_file>freestream_input</freestream_input_file>
+          <name>FreestreamMilne</name>
+          <freestream_input_file>freestream_input</freestream_input_file>
+          <E_DEP_FS>1</E_DEP_FS>
         </FreestreamMilne>
     </Preequilibrium>
 

--- a/src/preequilibrium/FreestreamMilneWrapper.cc
+++ b/src/preequilibrium/FreestreamMilneWrapper.cc
@@ -44,7 +44,6 @@ void FreestreamMilneWrapper::InitializePreequilibrium(
 
   std::string input_file = GetXMLElementText(
       {"Preequilibrium", "FreestreamMilne", "freestream_input_file"});
-  //is this necessary? if we just force the user to have the 'freestream_input' file in the correct directory
 
   fsmilne_ptr = new FREESTREAMMILNE();
   struct parameters *params = fsmilne_ptr->configure(input_file.c_str());
@@ -87,6 +86,20 @@ void FreestreamMilneWrapper::InitializePreequilibrium(
   //setting for the number of time steps
   int ntau = GetXMLElementInt({"Preequilibrium", "FreestreamMilne", "ntau"});
   params->NT = ntau;
+
+  //setting for the parameters E_DEP_FS, E_R, TAU_R, ALPHA
+  int E_DEP_FS = GetXMLElementInt(
+      {"Preequilibrium", "FreestreamMilne", "E_DEP_FS"});
+  double E_R = GetXMLElementDouble(
+      {"Preequilibrium", "FreestreamMilne", "E_R"});
+  double TAU_R = GetXMLElementDouble(
+      {"Preequilibrium", "FreestreamMilne", "TAU_R"});
+  double ALPHA = GetXMLElementDouble(
+      {"Preequilibrium", "FreestreamMilne", "ALPHA"});
+  params->E_DEP_FS = E_DEP_FS;
+  params->E_R = E_R;
+  params->TAU_R = TAU_R;
+  params->ALPHA = ALPHA;
 }
 
 void FreestreamMilneWrapper::EvolvePreequilibrium() {


### PR DESCRIPTION
This PR adds the energy density-dependent free streaming end time to the XML parameters.
I switched this off as a default and switched it on in the soft AA paper calibration paper XML. This way, the `taus` parameter really has the meaning one would expect. I also adjusted the value of `taus` to be 0.5 fm as a default, which is the default MUSIC `Initial_time_tau_0`.