### PR TITLE
Remove nPDF settings from AA hard paper XML and copy to separate XML

### DIFF
--- a/config/jetscape_user_PbPb_hard_nPDF.xml
+++ b/config/jetscape_user_PbPb_hard_nPDF.xml
@@ -27,6 +27,18 @@
       <pTHatMin>500</pTHatMin>
       <pTHatMax>550</pTHatMax>
       <eCM>5020</eCM>
+      <!-- You can add any number of additional lines to initialize pythia here -->
+      <!-- Note that if the tag exists it cannot be empty (tinyxml produces a segfault) -->
+      <!-- EPS09 Avg Nuclear PDF for nucleon in Pb nucleus -->
+      <LinesToRead>
+        HardQCD:all = on
+        PDF:useHardNPDFA=on
+        PDF:useHardNPDFB=on
+        PDF:nPDFSetA=1
+        PDF:nPDFSetB=1
+        PDF:nPDFBeamA = 100822080
+        PDF:nPDFBeamB = 100822080
+      </LinesToRead>
     </PythiaGun>
   </Hard>
 


### PR DESCRIPTION
This closes #248.

The nPDF setting is removed from the AA paper XML. The same file with the nPDF setting is stored in the `config` directory with the name `jetscape_user_PbPb_hard_nPDF.xml`. 