### PR TITLE
Centrality table update

### DIFF
--- a/config/jetscape_main.xml
+++ b/config/jetscape_main.xml
@@ -38,6 +38,7 @@
   <QnVector_rapmax>4</QnVector_rapmax>
   <QnVector_Nrap>80</QnVector_Nrap>
   <QnVector_Norder>7</QnVector_Norder>
+  <write_centrality> 0 </write_centrality>
   <write_pthat> 0 </write_pthat>
   <Writer>
     <FinalStateHadrons>

--- a/config/jetscape_main.xml
+++ b/config/jetscape_main.xml
@@ -38,6 +38,7 @@
   <QnVector_rapmax>4</QnVector_rapmax>
   <QnVector_Nrap>80</QnVector_Nrap>
   <QnVector_Norder>7</QnVector_Norder>
+  <!-- Printing the centrality to the event header is only possible for the Trento initial condition -->
   <write_centrality> 0 </write_centrality>
   <write_pthat> 0 </write_pthat>
   <Writer>

--- a/src/framework/InitialState.cc
+++ b/src/framework/InitialState.cc
@@ -58,6 +58,7 @@ void InitialState::CollectHeader(weak_ptr<JetScapeWriter> w) {
     auto &header = f->GetHeader();
     header.SetNpart(GetNpart());
     header.SetNcoll(GetNcoll());
+    header.SetEventCentrality(GetEventCentrality());
     header.SetTotalEntropy(GetTotalEntropy());
   }
 }

--- a/src/framework/InitialState.h
+++ b/src/framework/InitialState.h
@@ -73,6 +73,11 @@ public:
       To be overwritten by implementations that have such information.
   */
   virtual double GetTotalEntropy() { return -1; };
+  
+  /** Generated event centrality
+      To be overwritten by implementations that have such information.
+  */
+  virtual double GetEventCentrality() { return -1; };
 
   // one can set range by hand if not read from xml file
   /** Sets the range of the coordinates (xmax, ymax, zmax). 

--- a/src/framework/JetScapeEventHeader.h
+++ b/src/framework/JetScapeEventHeader.h
@@ -62,22 +62,22 @@ public:
   // ============================ Initial State =================================
   /// Initial State: Get number of participants
   double GetNpart() { return Npart; };
-  /// Initial State: Get number of participants
+  /// Initial State: Set number of participants
   void SetNpart(double d) { Npart = d; };
 
   /// Initial State: Get number of binary collisions
   double GetNcoll() { return Ncoll; };
-  /// Initial State: Get number of binary collisions
+  /// Initial State: Set number of binary collisions
   void SetNcoll(double d) { Ncoll = d; };
 
   /// Initial State: Get centrality of the event
   double GetEventCentrality() { return EventCentrality; }
-  /// Initial State: Get centrality of the event
+  /// Initial State: Set centrality of the event
   void SetEventCentrality(double d) { EventCentrality = d; }
 
   /// Initial State: Get total entropy
   double GetTotalEntropy() { return TotalEntropy; };
-  /// Initial State: Get total entropy
+  /// Initial State: Set total entropy
   void SetTotalEntropy(double d) { TotalEntropy = d; };
 
   // ============================ Hydro =================================

--- a/src/framework/JetScapeEventHeader.h
+++ b/src/framework/JetScapeEventHeader.h
@@ -70,6 +70,11 @@ public:
   /// Initial State: Get number of binary collisions
   void SetNcoll(double d) { Ncoll = d; };
 
+  /// Initial State: Get centrality of the event
+  double GetEventCentrality() { return EventCentrality; }
+  /// Initial State: Get centrality of the event
+  void SetEventCentrality(double d) { EventCentrality = d; }
+
   /// Initial State: Get total entropy
   double GetTotalEntropy() { return TotalEntropy; };
   /// Initial State: Get total entropy
@@ -92,6 +97,7 @@ private:
   double Npart = -1; // could be int, but using double to allow averaged values
   double Ncoll = -1; // could be int, but using double to allow averaged values
   double TotalEntropy = -1;
+  double EventCentrality = -1;
 
   // ============================ Hydro =================================
   double EventPlaneAngle = -999;

--- a/src/framework/JetScapeWriterFinalStateStream.cc
+++ b/src/framework/JetScapeWriterFinalStateStream.cc
@@ -63,6 +63,7 @@ RegisterJetScapeModule<JetScapeWriterFinalStateHadronsStream<ogzstream>>
 template <class T>
 JetScapeWriterFinalStateStream<T>::JetScapeWriterFinalStateStream(string m_file_name_out):
   particles{},
+  writeCentrality{false},
   writePtHat{false},
   particleStatusToSkip{}
 {
@@ -77,6 +78,13 @@ template <class T> JetScapeWriterFinalStateStream<T>::~JetScapeWriterFinalStateS
 
 template <class T> void JetScapeWriterFinalStateStream<T>::WriteEvent() {
   // Write the entire event all at once.
+
+  // Optionally write event centrality to event header
+  std::string centrality_text = "";
+  if (writeCentrality) {
+    centrality_text += "\tcentrality\t";
+    centrality_text += std::to_string(GetHeader().GetEventCentrality());
+  }
 
   // Optionally write pt-hat value to event header
   std::string pt_hat_text = "";
@@ -93,6 +101,7 @@ template <class T> void JetScapeWriterFinalStateStream<T>::WriteEvent() {
       << "\t" << "weight\t" << std::setprecision(15) << GetHeader().GetEventWeight() << std::setprecision(6)
       << "\t" << "EPangle\t" << (GetHeader().GetEventPlaneAngle() > -999 ? GetHeader().GetEventPlaneAngle() : 0)
       << "\t" << "N_" << GetName() << "\t" << particles.size()
+      << centrality_text
       << pt_hat_text
       <<  "\n";
 
@@ -123,7 +132,8 @@ template <class T> void JetScapeWriterFinalStateStream<T>::WriteEvent() {
 }
 
 template <class T> void JetScapeWriterFinalStateStream<T>::Init() {
-  // Whether to write the pt hat value for each event
+  // Whether to write the centrality and pt hat value for each event
+  writeCentrality = static_cast<bool>(JetScapeXML::Instance()->GetElementInt({"write_centrality"}));
   writePtHat = static_cast<bool>(JetScapeXML::Instance()->GetElementInt({"write_pthat"}));
 
   // Status codes to filter out from what is written (i.e. to be skipped)

--- a/src/framework/JetScapeWriterFinalStateStream.h
+++ b/src/framework/JetScapeWriterFinalStateStream.h
@@ -66,6 +66,7 @@ protected:
   T output_file; //!< Output file
   std::vector<std::shared_ptr<JetScapeParticleBase>> particles;
   bool writePtHat;
+  bool writeCentrality;
   std::vector<int> particleStatusToSkip;
 };
 

--- a/src/framework/JetScapeWriterFinalStateStream.h
+++ b/src/framework/JetScapeWriterFinalStateStream.h
@@ -65,8 +65,8 @@ public:
 protected:
   T output_file; //!< Output file
   std::vector<std::shared_ptr<JetScapeParticleBase>> particles;
-  bool writePtHat;
   bool writeCentrality;
+  bool writePtHat;
   std::vector<int> particleStatusToSkip;
 };
 

--- a/src/initialstate/TrentoInitial.cc
+++ b/src/initialstate/TrentoInitial.cc
@@ -327,7 +327,7 @@ std::pair<double, double> TrentoInitial::GenCenTab(std::string proj,
   // Step1: check it a table exist
   std::ifstream infile(filename);
   double Etab[101];
-  double buff1, buff2;
+  double buff;
   std::string line;
   if (infile.good()) {
     JSINFO << "The required centrality table exists. Load the table.";
@@ -335,7 +335,7 @@ std::pair<double, double> TrentoInitial::GenCenTab(std::string proj,
     while (std::getline(infile, line)) {
       if (line[0] != '#') {
         std::istringstream iss(line);
-        iss >> buff1 >> buff2 >> Etab[i];
+        iss >> buff >> Etab[i];
         i++;
       }
     }
@@ -356,16 +356,17 @@ std::pair<double, double> TrentoInitial::GenCenTab(std::string proj,
          << "#\t" << proj << "\t" << targ << "\t" << beamE << "\t" << xsection
          << "\t" << pvalue << "\t" << fluct << "\t" << nuclw << "\t" << dmin
          << "\n"
-         << "#\tcen_L\tcen_H\tun-normalized total density\n";
+         << "#\tcen, \tun-normalized total density\n";
     Etab[0] = 1e10;
+    fout << 0 << "\t" << Etab[0] << std::endl;
     for (int i = 1; i < 100; i += 1) {
       auto ee = event_records[i * nstep];
-      fout << i - 1 << "\t" << i << "\t" << ee.mult << std::endl;
+      fout << i << "\t" << ee.mult << std::endl;
       Etab[i] = ee.mult;
     }
-    auto ee = event_records.back();
-    fout << 99 << "\t" << 100 << "\t" << ee.mult << std::endl;
-    Etab[100] = ee.mult;
+    auto last_record = event_records.back();
+    fout << 100 << "\t" << last_record.mult << std::endl;
+    Etab[100] = last_record.mult;
     fout.close();
   }
   JSINFO << "#########" << Etab[cL] << " " << Etab[cH];

--- a/src/initialstate/TrentoInitial.cc
+++ b/src/initialstate/TrentoInitial.cc
@@ -216,6 +216,8 @@ void TrentoInitial::InitTask() {
   double cross_section = std::atof(phy_opts->Attribute("cross-section"));
   double normalization = std::atof(phy_opts->Attribute("normalization"));
 
+  info_.normalization = normalization;
+
   int cen_low = std::atoi(cut_opts->Attribute("centrality-low"));
   int cen_high = std::atoi(cut_opts->Attribute("centrality-high"));
 
@@ -260,9 +262,36 @@ void TrentoInitial::InitTask() {
     JSINFO << "TRENTo Minimum Biased Mode Generates 0-100(%) of nuclear "
               "inelastic cross-section";
   } else {
-    auto Ecut = GenCenTab(proj, targ, var_map_basic, cen_low, cen_high);
+    // Obtain Ecut and the centrality table filename
+    auto [Ecut, table_file] = GenCenTab(proj, targ, var_map_basic, cen_low, cen_high);
     double Ehigh = Ecut.first * normalization; // rescale the cut
     double Elow = Ecut.second * normalization; // rescale the cut
+
+    // Read the centrality table and store it
+    centrality_table_.clear();
+    std::ifstream infile(static_cast<std::string>(table_file));
+    if (!infile.good()) {
+      JSWARN << "Centrality table file not found!";
+      exit(-1);
+    }
+
+    // Skip header lines
+    std::string line;
+    while (std::getline(infile, line)) {
+        // Check if the line starts with '#', indicating a comment or header
+        if (line[0] == '#') {
+            continue; // Skip this line
+        }
+
+        // Parse data lines
+        double centrality_, density_;
+        std::istringstream iss(line);
+        if (iss >> centrality_ >> density_) {
+            centrality_table_.emplace_back(centrality_, density_);
+        }
+    }
+
+    infile.close();
 
     JSINFO << "The total energy density cut for centrality = [" << cen_low
            << ", " << cen_high << "] (%) is:";
@@ -290,7 +319,7 @@ bool compare_E(trento::records r1, trento::records r2) {
   return r1.mult > r2.mult;
 }
 
-std::pair<double, double> TrentoInitial::GenCenTab(std::string proj,
+std::pair<std::pair<double, double>, std::string> TrentoInitial::GenCenTab(std::string proj,
                                                    std::string targ,
                                                    VarMap var_map, int cL,
                                                    int cH) {
@@ -370,7 +399,31 @@ std::pair<double, double> TrentoInitial::GenCenTab(std::string proj,
     fout.close();
   }
   JSINFO << "#########" << Etab[cL] << " " << Etab[cH];
-  return std::make_pair(Etab[cL], Etab[cH]);
+  return std::make_pair(std::make_pair(Etab[cL], Etab[cH]), filename);
+}
+
+double TrentoInitial::LookupCentrality(double density) const {
+    // Check if the centrality table is empty
+    if (centrality_table_.empty()) {
+        JSWARN << "Centrality table is empty. Returning -1 for centrality.";
+        return -1.0; // Return a special value to indicate invalid centrality
+    }
+
+    // Iterate through the table to find the correct centrality bin
+    for (size_t i = 0; i < centrality_table_.size() - 1; ++i) {
+        double centrality_low = std::get<0>(centrality_table_[i]);
+        double centrality_high = std::get<0>(centrality_table_[i + 1]);
+        double current_density = std::get<1>(centrality_table_[i]);
+        double next_density = std::get<1>(centrality_table_[i + 1]);
+
+        // If the density falls between current and next, map it to centrality bin
+        if (density < current_density && density >= next_density) {
+            return (centrality_low + centrality_high) / 2.0; // Return the average of bin edges
+        }
+    }
+
+    // Density below the lowest range corresponds to 100% centrality
+    return 100.0;
 }
 
 void TrentoInitial::Exec() {
@@ -393,6 +446,15 @@ void TrentoInitial::Exec() {
   JSINFO << info_.impact_parameter << "\t" << info_.num_participant << "\t"
          << info_.num_binary_collisions << "\t" << info_.total_entropy << "\t"
          << "(" << info_.xmid << ", " << info_.ymid << ")";
+
+  // Calculate event centrality
+  // The centrality table needs "un-normalized total density"
+  info_.event_centrality = LookupCentrality(info_.total_entropy/info_.normalization);
+  if (info_.event_centrality == -1.0) {
+    JSINFO << "No centrality information available in Minimum Biased Mode.";
+  } else {
+    JSINFO << "Event centrality: " << info_.event_centrality;
+  }
 
   JSINFO << " Load TRENTo density and ncoll density to JETSCAPE memory ";
   auto density_field = tmp_event.density_grid();

--- a/src/initialstate/TrentoInitial.cc
+++ b/src/initialstate/TrentoInitial.cc
@@ -277,6 +277,7 @@ void TrentoInitial::InitTask() {
 
     // Skip header lines
     std::string line;
+    double centrality_ = 0.0, density_ = 0.0;
     while (std::getline(infile, line)) {
         // Check if the line starts with '#', indicating a comment or header
         if (line[0] == '#') {
@@ -284,7 +285,6 @@ void TrentoInitial::InitTask() {
         }
 
         // Parse data lines
-        double centrality_, density_;
         std::istringstream iss(line);
         if (iss >> centrality_ >> density_) {
             centrality_table_.emplace_back(centrality_, density_);

--- a/src/initialstate/TrentoInitial.h
+++ b/src/initialstate/TrentoInitial.h
@@ -40,6 +40,8 @@ typedef struct {
   double num_participant;
   double num_binary_collisions;
   double total_entropy;
+  double normalization;
+  double event_centrality;
   std::map<int, double> ecc; // order, eccentricity
   std::map<int, double> psi; // order, participant_plane
   double xmid, ymid;
@@ -65,6 +67,8 @@ public:
   void Clear();
   void InitTask();
 
+  double GetEventCentrality() { return(static_cast<double>(info_.event_centrality)); };
+
   struct RangeFailure : public std::runtime_error {
     using std::runtime_error::runtime_error;
   };
@@ -72,10 +76,14 @@ public:
 
 private:
   std::shared_ptr<trento::Collider> TrentoGen_;
-  std::pair<double, double> GenCenTab(std::string proj, std::string targ,
+  std::pair<std::pair<double, double>, std::string> GenCenTab(std::string proj, std::string targ,
                                       VarMap var_map, int cL, int cH);
   /// The output instance.
   // Output output_;
+
+  std::vector<std::pair<double, double>> centrality_table_; // Store (centrality, density)
+
+  double LookupCentrality(double density) const; // Helper for centrality lookup
 
   // Allows the registration of the module so that it is available to be used by the Jetscape framework.
   static RegisterJetScapeModule<TrentoInitial> reg;


### PR DESCRIPTION
This update is based on 3.6.7-RC. It addresses a bug related to the mismatch between centrality bins and their corresponding densities. Additionally, it implements event-by-event centrality determination based on Trento initial conditions, using the centrality bin table. The centrality of an event can optionally be written to the event header.