### PR TITLE
update the Glasma preEq wrapper

### DIFF
--- a/config/jetscape_main.xml
+++ b/config/jetscape_main.xml
@@ -93,9 +93,12 @@
     </LongiInputs>
     </Trento>
 
-    <!-- Options to read initial conditions from saved file  -->
+    <!-- Options to read initial conditions from saved file -->
     <initial_profile_path>../examples/test_hydro_files</initial_profile_path>
     <initial_Ncoll_list>../examples/test_hydro_files</initial_Ncoll_list>
+
+    <!-- In case IP-Glasma is used as initial condition, the parameters need to be specified in the 'ipglasma.input' file -->
+    <IPGlasma> </IPGlasma>
   </IS>
 
   <!-- Hard Process -->
@@ -245,6 +248,16 @@
       <!--ALPHA: power of the energy dependence for the energy dependent free streaming time-->
       <ALPHA>0.031</ALPHA>
     </FreestreamMilne>
+
+    <!-- Glasma pre-equilibrium stage for the IP-Glasma initial condition -->
+    <!-- These parameters should match the ones in 'ipglasma.input' -->
+    <!-- Other pre-equilibrium parameters are ignored in the Glasma case -->
+    <Glasma>
+      <tau0>0.001</tau0>
+      <taus>0.4</taus>
+      <dtau>0.005</dtau>
+      <input_filename_glasma>./epsilon-u-Hydro-t0.4-0.dat</input_filename_glasma>
+    </Glasma>
 
     <NullPreDynamics> </NullPreDynamics>
 

--- a/external_packages/get_ipglasma.sh
+++ b/external_packages/get_ipglasma.sh
@@ -13,5 +13,10 @@
 # See COPYING for details.
 ##############################################################################
 
+folderName="ipglasma"
+commitHash="215aea40fd3e0777f01c464cc4031fb2b4344449"
+
 # download the code package
-git clone --depth=1 -b InterfaceJETSCAPE https://github.com/chunshen1987/ipglasma ipglasma
+git clone --depth=1 -b InterfaceJETSCAPE https://github.com/chunshen1987/ipglasma $folderName
+cd $folderName
+git checkout $commitHash

--- a/src/initialstate/IPGlasmaWrapper.cc
+++ b/src/initialstate/IPGlasmaWrapper.cc
@@ -43,7 +43,7 @@ void IPGlasmaWrapper::InitTask() {
 
 void IPGlasmaWrapper::Exec() {
     Clear();
-    Jetscape::JSINFO << "Run IPGlasma ...";
+    Jetscape::JSINFO << "Run IP-Glasma ...";
     try {
         IPGlasma_ptr_->generateAnEvent(event_id_);
         event_id_++;

--- a/src/preequilibrium/Glasma.cc
+++ b/src/preequilibrium/Glasma.cc
@@ -37,7 +37,6 @@ void Glasma::EvolvePreequilibrium() {
     VERBOSE(2) << "Initialize density profiles in Glasma ...";
     std::string IPGlasmaFileName = "epsilon-u-Hydro-t0.4-0.dat";
     VERBOSE(2) << "Read in IPGlasma Tmunu ...";
-    const double norm = 0.235;
     std::ifstream IPGFile(IPGlasmaFileName.c_str());
     if (!IPGFile.good()) {
         Jetscape::JSWARN << "Can not open " << IPGlasmaFileName;
@@ -53,15 +52,15 @@ void Glasma::EvolvePreequilibrium() {
         double pi[10];
         IPGFile >> dummy >> dummy;
         IPGFile >> e_local >> u[0] >> u[1] >> u[2] >> u[3];
-        e_.push_back(norm*e_local*hbarC);
-        P_.push_back(norm*e_local*hbarC/3.);
+        e_.push_back(e_local);
+        P_.push_back(e_local/3.);
         utau_.push_back(u[0]);
         ux_.push_back(u[1]);
         uy_.push_back(u[2]);
         ueta_.push_back(u[3]);
         for (int i = 0; i < 10; i++) {
             IPGFile >> pi[i];
-            pi[i] *= norm*hbarC;
+            pi[i] *= hbarC;
         }
         pi00_.push_back(pi[0]);
         pi01_.push_back(pi[1]);

--- a/src/preequilibrium/Glasma.cc
+++ b/src/preequilibrium/Glasma.cc
@@ -20,6 +20,7 @@
 #include <fstream>
 
 #include "JetScapeLogger.h"
+#include "JetScapeXML.h"
 #include "JetScapeConstants.h"
 #include "Glasma.h"
 
@@ -33,10 +34,20 @@ Glasma::Glasma() {
     SetId("Glasma");
 }
 
+void Glasma::InitializePreequilibrium() {
+    preequilibrium_status_ = INIT;
+    preequilibrium_tau_0_ = GetXMLElementDouble({"Preequilibrium",
+                                                "Glasma", "tau0"});
+    preequilibrium_tau_max_ = GetXMLElementDouble({"Preequilibrium",
+                                                "Glasma", "taus"});
+    dtau_ = GetXMLElementDouble({"Preequilibrium", "Glasma", "dtau"});
+}
+
 void Glasma::EvolvePreequilibrium() {
     VERBOSE(2) << "Initialize density profiles in Glasma ...";
-    std::string IPGlasmaFileName = "epsilon-u-Hydro-t0.4-0.dat";
-    VERBOSE(2) << "Read in IPGlasma Tmunu ...";
+    std::string IPGlasmaFileName = GetXMLElementText({"Preequilibrium",
+                                    "Glasma", "input_filename_glasma"});
+    VERBOSE(2) << "Read in IP-Glasma Tmunu ...";
     std::ifstream IPGFile(IPGlasmaFileName.c_str());
     if (!IPGFile.good()) {
         Jetscape::JSWARN << "Can not open " << IPGlasmaFileName;

--- a/src/preequilibrium/Glasma.h
+++ b/src/preequilibrium/Glasma.h
@@ -26,13 +26,23 @@ public:
     Glasma();
     ~Glasma() {};
 
-    void InitializePreequilibrium() {preequilibrium_status_ = INIT;};
+    void InitializePreequilibrium() {
+        preequilibrium_status_ = INIT;
+        preequilibrium_tau_0_ = 0.001;
+        preequilibrium_tau_max_ = 0.4;
+        dtau_ = 0.005;
+    }
+
     void EvolvePreequilibrium();
+    Jetscape::real GetPreequilibriumEvodtau() const {
+        return(dtau_);
+    }
 
 private:
     // Allows the registration of the module so that it is available to be
     // used by the Jetscape framework.
     static RegisterJetScapeModule<Glasma> reg;
+    double dtau_;
 };
 
 #endif   // GLASMA_H

--- a/src/preequilibrium/Glasma.h
+++ b/src/preequilibrium/Glasma.h
@@ -26,12 +26,7 @@ public:
     Glasma();
     ~Glasma() {};
 
-    void InitializePreequilibrium() {
-        preequilibrium_status_ = INIT;
-        preequilibrium_tau_0_ = 0.001;
-        preequilibrium_tau_max_ = 0.4;
-        dtau_ = 0.005;
-    }
+    void InitializePreequilibrium();
 
     void EvolvePreequilibrium();
     Jetscape::real GetPreequilibriumEvodtau() const {


### PR DESCRIPTION
Following the current preEquilibrium module, we update the Glasma preEq module in JETSCAPE accordingly. This module is a fake wrapper, which only reads in the Tmunu from a local file and passes it to hydro. 

I correct the units in the Glasma module to avoid double counting when passing the Tmunu to MUSIC.