### PR TITLE
Make IP-Glasma CMake flag similar to other external codes

### DIFF
--- a/.github/workflows/test-build-external.yaml
+++ b/.github/workflows/test-build-external.yaml
@@ -64,5 +64,5 @@ jobs:
         mkdir build
         cd build
         export SMASH_DIR="${GITHUB_WORKSPACE}/${REPO_NAME}/external_packages/smash/smash_code"
-        cmake .. -DUSE_MUSIC=ON -DUSE_ISS=ON -DUSE_FREESTREAM=ON -DUSE_SMASH=ON -DUSE_IPGlasma=ON
+        cmake .. -DUSE_MUSIC=ON -DUSE_ISS=ON -DUSE_FREESTREAM=ON -DUSE_SMASH=ON -DUSE_IPGLASMA=ON
         make -j2

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -58,17 +58,17 @@ if (OPENCL_FOUND)
   endif (USE_CLVISC)
 endif (OPENCL_FOUND)
 
-# IPGlasma. Turn on with 'cmake -DUSE_IPGlasma=ON'.
-option(USE_IPGlasma "Build with IPGlasma " OFF)
-if (USE_IPGlasma)
-    message("Includes for IPGlasma ...")
+# IPGlasma. Turn on with 'cmake -DUSE_IPGLASMA=ON'.
+option(USE_IPGLASMA "Build with IP-Glasma" OFF)
+if (USE_IPGLASMA)
+    message("Includes for IP-Glasma ...")
     include_directories(./external_packages/ipglasma ./external_packages/ipglasma/src)
-endif (USE_IPGlasma)
+endif (USE_IPGLASMA)
 
 # MUSIC. Turn on with 'cmake -DUSE_MUSIC=ON'.
 option(USE_MUSIC "Build tests for MUSIC" OFF)
 if (USE_MUSIC)
-    message("Includes for music ...")
+    message("Includes for MUSIC ...")
     include_directories(./external_packages/music ./external_packages/music/src)
 endif (USE_MUSIC)
 
@@ -79,7 +79,7 @@ if (USE_ISS)
   include_directories(./external_packages/iSS ./external_packages/iSS/src)
 endif (USE_ISS)
 
-# SMASH afterburner. Turn on with 'cmake -DUSE_MUSIC=ON -DUSE_ISS=ON -Dsmash=ON'.
+# SMASH afterburner. Turn on with 'cmake -DUSE_MUSIC=ON -DUSE_ISS=ON -DSMASH=ON'.
 option(USE_SMASH "Build tests for SMASH" OFF)
 if (USE_SMASH)
   message("SMASH includes and library ...")

--- a/external_packages/README.md
+++ b/external_packages/README.md
@@ -125,7 +125,7 @@ cd build
 When compiling IP-Glasma with JETSCAPE, please turn on the IP-Glasma support option when generating the cmake configuration file.
 
 ```bash
-cmake .. -DUSE_MUSIC=ON -DUSE_ISS=ON -DUSE_FREESTREAM=ON -DUSE_SMASH=ON -DUSE_IPGlasma=ON
+cmake .. -DUSE_MUSIC=ON -DUSE_ISS=ON -DUSE_FREESTREAM=ON -DUSE_SMASH=ON -DUSE_IPGLASMA=ON
 
 make -j4  # Builds using 4 cores; adapt as appropriate
 ```


### PR DESCRIPTION
This makes the CMake flag for IP-Glasma similar to the ones for the other external packages (all capital letters) to avoid confusion for the user.