### PR TITLE
Bug fix for filtering final state particles in writer

### DIFF
--- a/config/jetscape_main.xml
+++ b/config/jetscape_main.xml
@@ -42,11 +42,13 @@
   <write_centrality> 0 </write_centrality>
   <write_pthat> 0 </write_pthat>
   <Writer>
+    <!-- Comma separated list of statuses to skip: e.g. "2, 3, 4" -->
+    <!-- -9999 corresponds to skipping no status code. It needs to have some entry to be avoid a segfault w/ empty values in tinyxml -->
     <FinalStateHadrons>
-      <statusToSkip></statusToSkip>
+        <statusToSkip>-9999</statusToSkip>
     </FinalStateHadrons>
     <FinalStatePartons>
-      <statusToSkip></statusToSkip>
+        <statusToSkip>-9999</statusToSkip>
     </FinalStatePartons>
   </Writer>
 


### PR DESCRIPTION
We write the number of particles into the event header, but if we filter particles, this number in the header won't match the number that's actually written.

(I had actually fixed this in a separate branch, but forgot to merge it when we merged the filtering - sorry!)