### PR TITLE
Write more info in the Qn vector output file (Enhancement #276)

### DIFF
--- a/src/framework/JetScapeWriterQnCalculator.h
+++ b/src/framework/JetScapeWriterQnCalculator.h
@@ -63,10 +63,10 @@ public:
   void WriteComment(string s) { }
   void WriteWhiteSpace(string s) { }
 
-
 protected:
   T output_file; //!< Output file
   std::vector<std::shared_ptr<Hadron>> particles;
+  bool writeCentrality;
   static RegisterJetScapeModule<JetScapeWriterQnVectorStream<ofstream>> regQnVector;
   static RegisterJetScapeModule<JetScapeWriterQnVectorStream<ogzstream>> regQnVectorGZ;
 private:
@@ -78,8 +78,6 @@ private:
   int nrap_;
   int norder_;
   std::map< int, int > chpdg_;
-  
-
 };
 
 


### PR DESCRIPTION
- The grid numbers and sizes for rapidity and pT, along with the number of harmonics are written in the header of the Qn vector output file.
- The event centrality for each event can be optionally written.
- Some empty lines are removed from the source code.

- Tested.