### PR TITLE
Updates minimum cmake required to 3.5 and installs MacOS workflow packages from source

### DIFF
--- a/.github/workflows/test-build-external.yaml
+++ b/.github/workflows/test-build-external.yaml
@@ -5,10 +5,12 @@ on:
     branches:
       - main
       - JETSCAPE-3.7.1-RC
+      - require_cmake_3_5
   push:
     branches:
       - main
       - JETSCAPE-3.7.1-RC
+      - require_cmake_3_5
 
 env:
   REPO_NAME: ${{ github.event.repository.name }}

--- a/.github/workflows/test-build-macos-native.yaml
+++ b/.github/workflows/test-build-macos-native.yaml
@@ -30,7 +30,6 @@ jobs:
         export NONINTERACTIVE=1
         brew update
         brew cleanup
-        brew install --formula cmake
         brew install --formula doxygen
         brew install --formula root
         brew install --formula graph-tool
@@ -39,6 +38,7 @@ jobs:
         brew install --formula gsl
         brew install --formula boost
         brew install --formula zlib
+        brew install --formula gcc
         . /opt/homebrew/bin/thisroot.sh
 
     - name: set environment variables
@@ -48,24 +48,75 @@ jobs:
         export LD_LIBRARY_PATH="$ROOTSYS/lib:$LD_LIBRARY_PATH"
         export PYTHONPATH="$ROOTSYS/lib"
 
-    - name: install HepMC 3.2.6
-      run: | # brew tap davidchall/hep
-        brew tap davidchall/homebrew-hep
-        cd $(brew --repository)/Library/Taps/davidchall/homebrew-hep
-        echo "Current directory: $(pwd)"
-        git checkout f643d5cacc19fd0b01d0ecba0daf30452152da03
-        NONINTERACTIVE=1 brew install davidchall/hep/hepmc3
-
-    - name: install Pythia 8309
+    - name: Download CMake 3.31.6
       run: |
-        cd $(brew --repository)/Library/Taps/davidchall/homebrew-hep
-        echo "Current directory: $(pwd)"
-        git checkout 141f8548d045df88d498ab44df16d2091742e4b1
-        NONINTERACTIVE=1 brew install davidchall/hep/pythia
+        curl -L -o cmake.dmg https://github.com/Kitware/CMake/releases/download/v3.31.6/cmake-3.31.6-macos-universal.dmg
+
+    - name: Mount CMake disk image
+      run: |
+        hdiutil attach cmake.dmg -mountpoint /Volumes/CMake
+
+    - name: Copy CMake.app to home directory
+      run: |
+        mkdir -p $HOME/cmake
+        cp -R /Volumes/CMake/CMake.app $HOME/cmake/
+
+    - name: Unmount CMake disk image
+      run: |
+        hdiutil detach /Volumes/CMake
+
+    - name: Add CMake to PATH
+      run: echo "$HOME/cmake/CMake.app/Contents/bin" >> $GITHUB_PATH
+
+    - name: Verify CMake version
+      run: cmake --version
+
+
+    - name: Download HepMC 3.2.6
+      run: |
+        curl -L -O http://hepmc.web.cern.ch/hepmc/releases/HepMC3-3.2.6.tar.gz
+        ls -l
+
+    - name: Build and Install HepMC 3.2.6
+      run: |
+        tar -xzf HepMC3-3.2.6.tar.gz
+        ls -l
+        cp -r HepMC3-3.2.6 hepmc3-source
+        mkdir hepmc3-build
+        cd hepmc3-build
+        cmake -DCMAKE_INSTALL_PREFIX=../hepmc3-install   \
+          -DHEPMC3_ENABLE_ROOTIO:BOOL=OFF            \
+          -DHEPMC3_ENABLE_PROTOBUFIO:BOOL=OFF        \
+          -DHEPMC3_ENABLE_TEST:BOOL=OFF              \
+          -DHEPMC3_INSTALL_INTERFACES:BOOL=ON        \
+          -DHEPMC3_BUILD_STATIC_LIBS:BOOL=OFF        \
+          -DHEPMC3_BUILD_DOCS:BOOL=OFF               \
+          -DHEPMC3_ENABLE_PYTHON:BOOL=ON             \
+          -DHEPMC3_PYTHON_VERSIONS=3.12              \
+          -DHEPMC3_Python_SITEARCH312=../hepmc3-install/lib/python3.12/site-packages \
+          ../hepmc3-source
+        make
+        make install
+
+    - name: Download Pythia 8309
+      run: |
+        cd ${GITHUB_WORKSPACE}
+        curl -SLOk http://pythia.org/download/pythia83/pythia8309.tgz
+        ls -l
+
+    - name: Build and Install Pythia 8309
+      run: |
+        tar -xzf pythia8309.tgz
+        ls -l
+        cd pythia8309
+        ./configure --enable-shared --prefix=${GITHUB_WORKSPACE}/pythia8309 --with-hepmc3=${GITHUB_WORKSPACE}/hepmc3-install
+        make
+        make install
 
     - name: set more variables
       run: |
-        export JETSCAPE_DIR="${GITHUB_WORKSPACE}/${REPO_NAME}"
+        echo "JETSCAPE_DIR=${GITHUB_WORKSPACE}/${REPO_NAME}" >> $GITHUB_ENV
+        echo "PYTHIA8DIR=${GITHUB_WORKSPACE}/pythia8309" >> $GITHUB_ENV
 
     - name: Checkout JETSCAPE Repository
       uses: actions/checkout@v4
@@ -89,7 +140,8 @@ jobs:
 
     - name: Download SMASH
       run: |
-        export PYTHIA8DIR="/opt/homebrew/opt/pythia"
+        echo "JETSCAPE_DIR is $JETSCAPE_DIR"
+        echo "PYTHIA8DIR is $PYTHIA8DIR"
         cd ${GITHUB_WORKSPACE}/${REPO_NAME}/external_packages
         ./get_smash.sh
 

--- a/.github/workflows/test-build-macos-native.yaml
+++ b/.github/workflows/test-build-macos-native.yaml
@@ -5,10 +5,12 @@ on:
     branches:
       - main
       - JETSCAPE-3.7.1-RC
+      - require_cmake_3_5
   push:
     branches:
       - main
       - JETSCAPE-3.7.1-RC
+      - require_cmake_3_5
 
 env:
   REPO_NAME: ${{ github.event.repository.name }}

--- a/.github/workflows/test-build-nPDF.yaml
+++ b/.github/workflows/test-build-nPDF.yaml
@@ -5,10 +5,12 @@ on:
     branches:
       - main
       - JETSCAPE-3.7.1-RC
+      - require_cmake_3_5
   push:
     branches:
       - main
       - JETSCAPE-3.7.1-RC
+      - require_cmake_3_5
 
 env:
   REPO_NAME: ${{ github.event.repository.name }}

--- a/.github/workflows/test-events-PbPb.yaml
+++ b/.github/workflows/test-events-PbPb.yaml
@@ -5,10 +5,12 @@ on:
     branches:
       - main
       - JETSCAPE-3.7.1-RC
+      - require_cmake_3_5
   push:
     branches:
       - main
       - JETSCAPE-3.7.1-RC
+      - require_cmake_3_5
 
 env:
   REPO_NAME: ${{ github.event.repository.name }}

--- a/.github/workflows/test-events-brick.yaml
+++ b/.github/workflows/test-events-brick.yaml
@@ -6,11 +6,13 @@ on:
       - main
       - brick_matter_lbt
       - JETSCAPE-3.7.1-RC
+      - require_cmake_3_5
   push:
     branches:
       - main
       - brick_matter_lbt
       - JETSCAPE-3.7.1-RC
+      - require_cmake_3_5
 
 env:
   REPO_NAME: ${{ github.event.repository.name }}

--- a/.github/workflows/test-events-pp.yaml
+++ b/.github/workflows/test-events-pp.yaml
@@ -5,10 +5,12 @@ on:
     branches:
       - main
       - JETSCAPE-3.7.1-RC
+      - require_cmake_3_5
   push:
     branches:
       - main
       - JETSCAPE-3.7.1-RC
+      - require_cmake_3_5
 
 env:
   REPO_NAME: ${{ github.event.repository.name }}

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,7 +2,7 @@
 ### Initial Cmake Setup ###
 ###########################
 
-cmake_minimum_required(VERSION 3.0 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.5 FATAL_ERROR)
 project (JetScape CXX C)
 
 # Fail if cmake is called in the source directory

--- a/external_packages/CMakeLists.txt
+++ b/external_packages/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.0 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.5 FATAL_ERROR)
 project (libJetScapeThird)
 
 #for MacOSX

--- a/external_packages/clvisc_wrapper/CMakeLists.txt
+++ b/external_packages/clvisc_wrapper/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.0)
+cmake_minimum_required(VERSION 3.5)
 project(clviscwrapper)
 
 #for MacOSX

--- a/external_packages/googletest/CMakeLists.txt
+++ b/external_packages/googletest/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.6.4)
+cmake_minimum_required(VERSION 3.5)
 
 project( googletest-distribution )
 

--- a/external_packages/googletest/googlemock/CMakeLists.txt
+++ b/external_packages/googletest/googlemock/CMakeLists.txt
@@ -38,7 +38,7 @@ endif()
 # ${gmock_BINARY_DIR}.
 # Language "C" is required for find_package(Threads).
 project(gmock CXX C)
-cmake_minimum_required(VERSION 2.6.4)
+cmake_minimum_required(VERSION 3.5)
 
 if (COMMAND set_up_hermetic_build)
   set_up_hermetic_build()

--- a/external_packages/googletest/googletest/CMakeLists.txt
+++ b/external_packages/googletest/googletest/CMakeLists.txt
@@ -45,7 +45,7 @@ endif()
 # ${gtest_BINARY_DIR}.
 # Language "C" is required for find_package(Threads).
 project(gtest CXX C)
-cmake_minimum_required(VERSION 2.6.4)
+cmake_minimum_required(VERSION 3.5)
 
 if (COMMAND set_up_hermetic_build)
   set_up_hermetic_build()

--- a/external_packages/googletest/googletest/README.md
+++ b/external_packages/googletest/googletest/README.md
@@ -121,7 +121,7 @@ main build with `add_subdirectory()`. For example:
 
 New file `CMakeLists.txt.in`:
 
-    cmake_minimum_required(VERSION 2.8.2)
+    cmake_minimum_required(VERSION 3.5)
  
     project(googletest-download NONE)
  

--- a/external_packages/gtl/CMakeLists.txt
+++ b/external_packages/gtl/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.0 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.5 FATAL_ERROR)
 project (GTL)
 
 cmake_policy(SET CMP0042 NEW)

--- a/external_packages/gtl/src/CMakeLists.txt
+++ b/external_packages/gtl/src/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.0 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.5 FATAL_ERROR)
 project (GTL_LIB)
 
 #for MacOSX

--- a/external_packages/gtl/tests/CMakeLists.txt
+++ b/external_packages/gtl/tests/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.0 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.5 FATAL_ERROR)
 project (glt_test)
 
 cmake_policy(SET CMP0042 NEW)

--- a/external_packages/hydro_from_external_file/CMakeLists.txt
+++ b/external_packages/hydro_from_external_file/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.0 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.5 FATAL_ERROR)
 project (lib_Hydro_from_file)
 
 #for MacOSX

--- a/external_packages/trento/CMakeLists.txt
+++ b/external_packages/trento/CMakeLists.txt
@@ -1,5 +1,5 @@
 
-cmake_minimum_required(VERSION 3.4)
+cmake_minimum_required(VERSION 3.5)
 project(trento VERSION 1.5.1 LANGUAGES CXX)
 
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.0 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.5 FATAL_ERROR)
 project (libJetScape)
 
 #for MacOSX


### PR DESCRIPTION
This PR updates JETSCAPE's CMakeLists minimum version required parameter to 3.5 from 3.0, as the new cmake 4.0 requires projects built using cmake to require cmake 3.5 as a minimum.

Also, the GitHub Actions workflow that builds and tests a native MacOS installation has been updated to install cmake, Pythia 8.309, and HepMC3 3.2.6 from source instead of from Homebrew or Homebrew taps.  This resolves the issue where checking out older brew commits to get these specific older versions of Pythia and HepMC3 failed on account of the new cmake minimum requirement.