### PR TITLE
Update LBT get script

### DIFF
--- a/.github/workflows/test-events-brick.yaml
+++ b/.github/workflows/test-events-brick.yaml
@@ -5,14 +5,12 @@ on:
     branches:
       - main
       - brick_matter_lbt
-      - JETSCAPE-3.7.1-RC
-      - require_cmake_3_5
+      - latessa/lbt-test
   push:
     branches:
       - main
       - brick_matter_lbt
-      - JETSCAPE-3.7.1-RC
-      - require_cmake_3_5
+      - latessa/lbt-test
 
 env:
   REPO_NAME: ${{ github.event.repository.name }}

--- a/external_packages/get_lbtTab.sh
+++ b/external_packages/get_lbtTab.sh
@@ -12,12 +12,72 @@
 # Distributed under the GNU General Public License 3.0 (GPLv3 or later).
 # See COPYING for details.
 ##############################################################################
- 
-# download the tables required by LBT code
-curlcmd=wget
-command -v ${curlcmd} > /dev/null || curlcmd="curl -LO"
-command -v ${curlcmd} > /dev/null || { echo "Please install curl or wget" ; exit 1; }
-$curlcmd "https://bitbucket.org/sscao/lbt-tables-new/downloads/LBT-tables.tar.gz"
 
-tar xvzf LBT-tables.tar.gz
+# clone the lbt-tables repository
+repo_dir="LBT-tables-repo"
+git clone https://github.com/JETSCAPE/LBT-tables.git "$repo_dir"
 
+# temporary directory where the split LBT tables will be extracted
+split_extract_dir="tmp/LBT-tables-split-extract"
+
+# where the final unsplit LBT tables will be placed
+unsplit_dir="LBT-tables"
+
+if [ ! -d "$repo_dir/LBT-tables-split-archive" ]; then
+    echo "Error archive directory does not exist."
+    exit 1
+fi
+
+mkdir -p $split_extract_dir
+mkdir -p $unsplit_dir
+
+# extract all the .tar.gz files to the temporary directory
+for file in "$repo_dir/LBT-tables-split-archive"/*.tar.gz; do
+    if [ -f "$file" ]; then
+        tar -xzf "$file" -C "$split_extract_dir"
+        echo "Extracted '$file' to '$split_extract_dir'"
+    else
+        echo "Error '$file' does not conform to .tar.gz format."
+        exit 1
+    fi
+done
+
+# an associative array (map) for base names. eg. myFile.part0 and 
+# myFile.part1 will share the base name myFile
+declare -A base_names
+
+# populate the base_names map with the unique base names
+for file in "$split_extract_dir"/*; do
+    filename=$(basename "$file")
+    if [[ "$filename" =~ \.part([0-9]+)$ ]]; then
+        base_name="${filename%.part*}"
+        base_names["$base_name"]=1
+    else
+        echo "Error: '$filename' - all files must end with .partN, where N is a positive integer."
+    fi
+done
+
+for base_name in "${!base_names[@]}"; do
+    # sort parts numerically (not lexicographically) so a .part10 will not be appended before .part2
+    part_files=($(ls "$split_extract_dir"/"$base_name".part* 2>/dev/null | sort -V))
+
+    # if a file is small enough that it has only one part (.part0), copy it to the unsplit directory
+    if [ ${#part_files[@]} -eq 1 ] && [[ "${part_files[0]}" == "$split_extract_dir/$base_name.part0" ]]; then
+        cp "${part_files[0]}" "$unsplit_dir/$base_name"
+        echo "Copied '${part_files[0]}' to '$unsplit_dir/$base_name'"
+    else
+        # concatenate the multiple parts, writing the file to the unsplit directory
+        output_file="$unsplit_dir/$base_name"
+        > "$output_file"
+        for part in "${part_files[@]}"; do
+            cat "$part" >> "$output_file"
+            echo "Added '$part' to '$output_file'"
+        done
+    fi
+done
+
+# remove the temporary extracted split files
+rm -rf tmp
+
+# remove the local lbt-tables repository if not wanted
+# rm -rf "$repo_dir"


### PR DESCRIPTION
This PR updates the LBT tables get script to clone from a new JETSCAPE Organization repo.  The get script then extracts and merges the LBT tables to the format JETSCAPE expects.

This is currently a pull request to main as it only changes an external packages get script and doesn't touch the JETSCAPE code.  However, if an updated versioned release is preferred, I can redirect this to a new release candidate.  Whichever is preferred, I'll also do the same for X-SCAPE.