### PR TITLE
Initialization fixes

### DIFF
--- a/src/framework/FluidDynamics.cc
+++ b/src/framework/FluidDynamics.cc
@@ -50,16 +50,18 @@ void FluidDynamics::Init() {
 
   VERBOSE(8);
   ini = JetScapeSignalManager::Instance()->GetInitialStatePointer().lock();
-  if (!ini) {
-    JSWARN << "No initialization module, "
+  if (!ini and GetId()!="Brick") {
+    JSWARN << "No initial state module, "
            << "try: auto trento = make_shared<TrentoInitial>(); "
            << "jetscape->Add(trento);";
+    exit(-1);
   }
 
   pre_eq_ptr =
       JetScapeSignalManager::Instance()->GetPreEquilibriumPointer().lock();
-  if (!pre_eq_ptr) {
+  if (!pre_eq_ptr and GetId()!="Brick") {
     JSWARN << "No Pre-equilibrium module";
+    exit(-1);
   }
 
   InitializeHydro(parameter_list);

--- a/src/framework/HardProcess.cc
+++ b/src/framework/HardProcess.cc
@@ -52,9 +52,11 @@ void HardProcess::Init() {
   if (!ini) {
     // If not vacuum case, give warning to add initial state module
     bool in_vac = GetXMLElementInt({"Eloss", "Matter", "in_vac"});
-    if (!in_vac) {
+    bool in_brick = GetXMLElementInt({"Eloss", "Matter", "brick_med"});
+    if (!in_vac and !in_brick) {
       JSWARN << "No initial state module! Please check whether you intend to "
                 "add an initial state module.";
+      exit(-1);
     }
   }
   string status = GetXMLElementText({"PartonPrinter", "Status"});

--- a/src/framework/PreequilibriumDynamics.cc
+++ b/src/framework/PreequilibriumDynamics.cc
@@ -49,9 +49,10 @@ void PreequilibriumDynamics::Init() {
   // this is grabbing the initial entropy density ?
   ini = JetScapeSignalManager::Instance()->GetInitialStatePointer().lock();
   if (!ini) {
-    JSWARN << "No initialization module, try: "
+    JSWARN << "No initial state module, try: "
            << "auto trento = make_shared<TrentoInitial>(); "
            << "jetscape->Add(trento);";
+    exit(-1);
   }
 
   preequilibrium_tau_0_ = GetXMLElementDouble({"Preequilibrium", "tau0"});


### PR DESCRIPTION
Adding exits for no initial state scenarios and removing unneeded brick warnings, ported from X-SCAPE changes