### PR TITLE
Fix store_hydro_info_in_memory flag issue

### DIFF
--- a/src/hydro/MusicWrapper.cc
+++ b/src/hydro/MusicWrapper.cc
@@ -75,6 +75,8 @@ void MpiMusic::InitializeHydro(Parameter parameter_list) {
     music_hydro_ptr->set_parameter("output_evolution_every_N_timesteps",
       GetXMLElementInt({"Hydro", "MUSIC", "output_evolution_every_N_timesteps"})
     );
+  } else {
+    music_hydro_ptr->set_parameter("store_hydro_info_in_memory", 0);
   }
 
   double tau_hydro = (


### PR DESCRIPTION
This allows to set the `store_hydro_info_in_memory` flag to 0 in the XML user file.

The solution should at least partially fix #288.