### PR TITLE
update cmake error message for when SMASH is turned on but not found

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -86,6 +86,8 @@ if (USE_SMASH)
   find_package(SMASH)
   if(${SMASH_FOUND})
     include_directories(${SMASH_INCLUDE_DIR})
+  else()
+    message(FATAL_ERROR "SMASH is not found. Ensure SMASH_DIR is properly set.")
   endif(${SMASH_FOUND})
 endif (USE_SMASH)
 


### PR DESCRIPTION
Per @chunshen1987's suggestion, this PR provides a more meanginful error message when SMASH is turned on in CMAKE but not found, which may occur when using Apptainer/Singularity if the SMASH_DIR environment variable is not correctly set.