### PR TITLE
Update MacOS Automated Test Workflow

### DIFF
--- a/.github/workflows/test-build-macos-native.yaml
+++ b/.github/workflows/test-build-macos-native.yaml
@@ -5,10 +5,12 @@ on:
     branches:
       - main
       - JETSCAPE-3.7.2-RC
+      - latessa/macos_workflow_boost_pin
   push:
     branches:
       - main
       - JETSCAPE-3.7.2-RC
+      - latessa/macos_workflow_boost_pin
 
 env:
   REPO_NAME: ${{ github.event.repository.name }}
@@ -34,7 +36,7 @@ jobs:
         brew install --formula hdf5
         brew install --formula open-mpi
         brew install --formula gsl
-        brew install --formula boost
+        brew install --formula boost@1.85
         brew install --formula zlib
         brew install --formula gcc
         . /opt/homebrew/bin/thisroot.sh
@@ -149,10 +151,17 @@ jobs:
         mkdir build
         cd build
         export SMASH_DIR="${GITHUB_WORKSPACE}/${REPO_NAME}/external_packages/smash/smash_code"
+        BOOST_ROOT="$(brew --prefix boost@1.85)"
         echo "This is SMASH_DIR: "
         echo ${SMASH_DIR}
         ls ${SMASH_DIR}
-        cmake .. -DUSE_MUSIC=ON -DUSE_ISS=ON -DUSE_FREESTREAM=ON -DUSE_SMASH=ON
+        cmake .. \
+          -DUSE_MUSIC=ON \
+          -DUSE_ISS=ON \
+          -DUSE_FREESTREAM=ON \
+          -DUSE_SMASH=ON \
+          -DCMAKE_PREFIX_PATH="$BOOST_ROOT" \
+          -DBoost_NO_BOOST_CMAKE=ON
         make -j2
 
     - name: Test Run


### PR DESCRIPTION
This change accommodates a MacOS homebrew update that affects how cmake looks for boost. The issue only affects native MaOS installations, so the automated native MacOS workflow is amended here.