### PR TITLE
Implement SMASH 3.2.2

### DIFF
--- a/config/jetscape_main.xml
+++ b/config/jetscape_main.xml
@@ -498,6 +498,8 @@
       <end_time>1000.0</end_time>
       <!-- 0 - run the full afterburner, 1 - only decay the resonances without even propagation -->
       <only_decays>0</only_decays>
+      <!-- time steps in the SMASH afterburner -->
+      <Delta_Time>0.05</Delta_Time>
     </SMASH>
   </Afterburner>
 </jetscape>


### PR DESCRIPTION
I open this as a draft already. Implementing this requires to have Pythia 8.315 installed, which also requires updates of the test files then.

I suggest we merge this when we have finished the performance improvements and documentation steps.

I based this on the `src_framework_documentation` branch that is supposed to be merged before this one. The only changes are in the `SmashWrapper.cc` file and the main XML.