### PR TITLE
Configure Tests for Updated Pythia

### DIFF
--- a/.github/workflows/plot_observables.yaml
+++ b/.github/workflows/plot_observables.yaml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-latest
     
     container:
-      image: jetscape/base:v1.11
+      image: jetscape/base:v1.13
       options: --user root
       
     steps:

--- a/.github/workflows/test-build-external.yaml
+++ b/.github/workflows/test-build-external.yaml
@@ -5,14 +5,12 @@ on:
     branches:
       - main
       - JETSCAPE-4.0.1-RC
-      - parallel_surfacefinder_new_cornelius_rc
-      - latessa/rMatter_test
+      - prep_4.0.1_smash
   push:
     branches:
       - main
       - JETSCAPE-4.0.1-RC
-      - parallel_surfacefinder_new_cornelius_rc
-      - latessa/rMatter_test
+      - prep_4.0.1_smash
 
 env:
   REPO_NAME: ${{ github.event.repository.name }}
@@ -23,7 +21,7 @@ jobs:
     runs-on: ubuntu-latest
     
     container:
-      image: jetscape/base:v1.11
+      image: jetscape/base:v1.13
       options: --user root
       
     steps:

--- a/.github/workflows/test-build-macos-native.yaml
+++ b/.github/workflows/test-build-macos-native.yaml
@@ -113,25 +113,25 @@ jobs:
         echo "HEPMC3_DIR=${GITHUB_WORKSPACE}/hepmc3-install" >> $GITHUB_ENV
         echo "Set HEPMC3_DIR=${GITHUB_WORKSPACE}/hepmc3-install"
 
-    - name: Download Pythia 8309
+    - name: Download Pythia 8315
       run: |
         cd ${GITHUB_WORKSPACE}
-        curl -SLOk http://pythia.org/download/pythia83/pythia8309.tgz
+        curl -SLOk http://pythia.org/download/pythia83/pythia8315.tgz
         ls -l
 
-    - name: Build and Install Pythia 8309
+    - name: Build and Install Pythia 8315
       run: |
-        tar -xzf pythia8309.tgz
+        tar -xzf pythia8315.tgz
         ls -l
-        cd pythia8309
-        ./configure --enable-shared --prefix=${GITHUB_WORKSPACE}/pythia8309 --with-hepmc3=${GITHUB_WORKSPACE}/hepmc3-install
+        cd pythia8315
+        ./configure --enable-shared --prefix=${GITHUB_WORKSPACE}/pythia8315 --with-hepmc3=${GITHUB_WORKSPACE}/hepmc3-install
         make
         make install
 
     - name: set more variables
       run: |
         echo "JETSCAPE_DIR=${GITHUB_WORKSPACE}/${REPO_NAME}" >> $GITHUB_ENV
-        echo "PYTHIA8DIR=${GITHUB_WORKSPACE}/pythia8309" >> $GITHUB_ENV
+        echo "PYTHIA8DIR=${GITHUB_WORKSPACE}/pythia8315" >> $GITHUB_ENV
 
     - name: Checkout JETSCAPE Repository
       uses: actions/checkout@v4

--- a/.github/workflows/test-build-macos-native.yaml
+++ b/.github/workflows/test-build-macos-native.yaml
@@ -5,14 +5,12 @@ on:
     branches:
       - main
       - JETSCAPE-4.0.1-RC
-      - parallel_surfacefinder_new_cornelius_rc
-      - latessa/rMatter_test
+      - prep_4.0.1_smash
   push:
     branches:
       - main
       - JETSCAPE-4.0.1-RC
-      - parallel_surfacefinder_new_cornelius_rc
-      - latessa/rMatter_test
+      - prep_4.0.1_smash
 
 env:
   REPO_NAME: ${{ github.event.repository.name }}

--- a/.github/workflows/test-build-nPDF.yaml
+++ b/.github/workflows/test-build-nPDF.yaml
@@ -5,14 +5,12 @@ on:
     branches:
       - main
       - JETSCAPE-4.0.1-RC
-      - parallel_surfacefinder_new_cornelius_rc
-      - latessa/rMatter_test
+      - prep_4.0.1_smash
   push:
     branches:
       - main
       - JETSCAPE-4.0.1-RC
-      - parallel_surfacefinder_new_cornelius_rc
-      - latessa/rMatter_test
+      - prep_4.0.1_smash
 
 env:
   REPO_NAME: ${{ github.event.repository.name }}
@@ -23,7 +21,7 @@ jobs:
     runs-on: ubuntu-latest
 
     container:
-      image: jetscape/base:v1.11
+      image: jetscape/base:v1.13
       options: --user root
       
     steps:

--- a/.github/workflows/test-code-format.yaml
+++ b/.github/workflows/test-code-format.yaml
@@ -5,14 +5,12 @@ on:
     branches:
       - main
       - JETSCAPE-4.0.1-RC
-      - parallel_surfacefinder_new_cornelius_rc
-      - latessa/rMatter_test
+      - prep_4.0.1_smash
   push:
     branches:
       - main
       - JETSCAPE-4.0.1-RC
-      - parallel_surfacefinder_new_cornelius_rc
-      - latessa/rMatter_test
+      - prep_4.0.1_smash
 env:
   REPO_NAME: ${{ github.event.repository.name }}
 

--- a/.github/workflows/test-events-PbPb.yaml
+++ b/.github/workflows/test-events-PbPb.yaml
@@ -43,7 +43,7 @@ jobs:
       uses: actions/checkout@v4
       with:
         repository: JETSCAPE/TEST-EXAMPLES
-        ref: jetscape-4.0
+        ref: xscape-2.0.1
         path: TEST-EXAMPLES
       
     - name: Run Pb-Pb tests

--- a/.github/workflows/test-events-PbPb.yaml
+++ b/.github/workflows/test-events-PbPb.yaml
@@ -5,14 +5,12 @@ on:
     branches:
       - main
       - JETSCAPE-4.0.1-RC
-      - parallel_surfacefinder_new_cornelius_rc
-      - latessa/rMatter_test
+      - prep_4.0.1_smash
   push:
     branches:
       - main
       - JETSCAPE-4.0.1-RC
-      - parallel_surfacefinder_new_cornelius_rc
-      - latessa/rMatter_test
+      - prep_4.0.1_smash
 
 env:
   REPO_NAME: ${{ github.event.repository.name }}
@@ -23,7 +21,7 @@ jobs:
     runs-on: ubuntu-latest
     
     container:
-      image: jetscape/base:v1.11
+      image: jetscape/base:v1.13
       options: --user root
       
     steps:

--- a/.github/workflows/test-events-brick.yaml
+++ b/.github/workflows/test-events-brick.yaml
@@ -47,7 +47,7 @@ jobs:
       uses: actions/checkout@v4
       with:
         repository: JETSCAPE/TEST-EXAMPLES
-        ref: main
+        ref: jetscape-4.0.1
         path: TEST-EXAMPLES
 
     - name: Run Brick Matter Lbt tests

--- a/.github/workflows/test-events-brick.yaml
+++ b/.github/workflows/test-events-brick.yaml
@@ -5,14 +5,12 @@ on:
     branches:
       - main
       - JETSCAPE-4.0.1-RC
-      - parallel_surfacefinder_new_cornelius_rc
-      - latessa/rMatter_test
+      - prep_4.0.1_smash
   push:
     branches:
       - main
       - JETSCAPE-4.0.1-RC
-      - parallel_surfacefinder_new_cornelius_rc
-      - latessa/rMatter_test
+      - prep_4.0.1_smash
 env:
   REPO_NAME: ${{ github.event.repository.name }}
 
@@ -22,7 +20,7 @@ jobs:
     runs-on: ubuntu-latest
 
     container:
-      image: jetscape/base:v1.11
+      image: jetscape/base:v1.13
       options: --user root
 
     steps:

--- a/.github/workflows/test-events-pp.yaml
+++ b/.github/workflows/test-events-pp.yaml
@@ -43,7 +43,7 @@ jobs:
       uses: actions/checkout@v4
       with:
         repository: JETSCAPE/TEST-EXAMPLES
-        ref: jetscape-4.0
+        ref: xscape-2.0.1
         path: TEST-EXAMPLES
       
     - name: Run pp tests

--- a/.github/workflows/test-events-pp.yaml
+++ b/.github/workflows/test-events-pp.yaml
@@ -5,14 +5,12 @@ on:
     branches:
       - main
       - JETSCAPE-4.0.1-RC
-      - parallel_surfacefinder_new_cornelius_rc
-      - latessa/rMatter_test
+      - prep_4.0.1_smash
   push:
     branches:
       - main
       - JETSCAPE-4.0.1-RC
-      - parallel_surfacefinder_new_cornelius_rc
-      - latessa/rMatter_test
+      - prep_4.0.1_smash
 
 env:
   REPO_NAME: ${{ github.event.repository.name }}
@@ -23,7 +21,7 @@ jobs:
     runs-on: ubuntu-latest
     
     container:
-      image: jetscape/base:v1.11
+      image: jetscape/base:v1.13
       options: --user root
       
     steps:

--- a/cmakemodules/FindSMASH.cmake
+++ b/cmakemodules/FindSMASH.cmake
@@ -22,9 +22,9 @@ endif()
 message(STATUS "Looking for SMASH ...")
 
 set(SMASH_INCLUDE_DIR
-  $ENV{SMASH_DIR}/3rdparty/Cuba-4.2.2 $ENV{SMASH_DIR}/3rdparty/einhard
-  $ENV{SMASH_DIR}/3rdparty/yaml-cpp-0.8.0/include
-  $ENV{SMASH_DIR}/build/src/include $ENV{SMASH_DIR}/src/include)
+    $ENV{SMASH_DIR}/3rdparty/Cuba-4.2.2 $ENV{SMASH_DIR}/3rdparty/einhard
+    $ENV{SMASH_DIR}/3rdparty/yaml-cpp-0.8.0/include
+    $ENV{SMASH_DIR}/build/src/include $ENV{SMASH_DIR}/src/include)
 message(STATUS "SMASH includes found in ${SMASH_INCLUDE_DIR}")
 
 find_library(

--- a/cmakemodules/FindSMASH.cmake
+++ b/cmakemodules/FindSMASH.cmake
@@ -22,9 +22,9 @@ endif()
 message(STATUS "Looking for SMASH ...")
 
 set(SMASH_INCLUDE_DIR
-    $ENV{SMASH_DIR}/3rdparty/Cuba-4.2.1 $ENV{SMASH_DIR}/3rdparty/einhard
-    $ENV{SMASH_DIR}/3rdparty/yaml-cpp-0.7.0/include
-    $ENV{SMASH_DIR}/build/src/include $ENV{SMASH_DIR}/src/include)
+  $ENV{SMASH_DIR}/3rdparty/Cuba-4.2.2 $ENV{SMASH_DIR}/3rdparty/einhard
+  $ENV{SMASH_DIR}/3rdparty/yaml-cpp-0.8.0/include
+  $ENV{SMASH_DIR}/build/src/include $ENV{SMASH_DIR}/src/include)
 message(STATUS "SMASH includes found in ${SMASH_INCLUDE_DIR}")
 
 find_library(
@@ -38,11 +38,11 @@ find_library(
 find_library(
   CPPYAML_LIBRARY
   NAMES yaml-cpp
-  PATHS $ENV{SMASH_DIR}/build/3rdparty/yaml-cpp-0.7.0)
+  PATHS $ENV{SMASH_DIR}/build/3rdparty/yaml-cpp-0.8.0)
 find_library(
   INTEGRATION_LIBRARY
   NAMES cuhre
-  PATHS $ENV{SMASH_DIR}/build/3rdparty/Cuba-4.2.1/src/cuhre)
+  PATHS $ENV{SMASH_DIR}/build/3rdparty/Cuba-4.2.2/src/cuhre)
 set(SMASH_LIBRARIES
     ${EINHARD_LIBRARY} ${CPPYAML_LIBRARY} ${SMASH_PYTHIA_LIBRARY}
     ${SMASH_LIBRARY} ${INTEGRATION_LIBRARY})

--- a/config/jetscape_main.xml
+++ b/config/jetscape_main.xml
@@ -498,6 +498,8 @@
       <end_time>1000.0</end_time>
       <!-- 0 - run the full afterburner, 1 - only decay the resonances without even propagation -->
       <only_decays>0</only_decays>
+      <!-- time steps in the SMASH afterburner -->
+      <Delta_Time>0.05</Delta_Time>
     </SMASH>
   </Afterburner>
 </jetscape>

--- a/external_packages/get_smash.sh
+++ b/external_packages/get_smash.sh
@@ -14,7 +14,7 @@
 ##############################################################################
 
 # 1) Download the SMASH code
-git clone --depth=1 https://github.com/smash-transport/smash.git --branch SMASH-3.0 smash/smash_code
+git clone --depth=1 https://github.com/smash-transport/smash.git --branch SMASH-3.2.2 smash/smash_code
 
 # 2) Compile SMASH
 cd smash/smash_code


### PR DESCRIPTION
The PR configures the automated tests to use reference files created using Pythia 8.315.  It also amends the get_smash.sh script to use SMASH version 3.2.2 and updates the FindSMASH cmakemodule.

All changes from pull request #299 are also included.