### PR TITLE
run build test on both AMD64 and ARM64 instances

### DIFF
--- a/.github/workflows/test-build-external.yaml
+++ b/.github/workflows/test-build-external.yaml
@@ -16,61 +16,64 @@ env:
 jobs:
   build:
     name: external packages (${{ matrix.arch }})
-    runs-on: ubuntu-latest
-
     strategy:
       matrix:
-        arch: [amd64, arm64]
+        include:
+          - arch: amd64
+            runs-on: ubuntu-24.04
+          - arch: arm64
+            runs-on: ubuntu-24.04-arm
+
+    runs-on: ${{ matrix.runs-on }}
 
     container:
       image: jetscape/base:v2.0
-      options: --user root --platform=linux/${{ matrix.arch }}
-      
+      options: --user root
+
     steps:
-      
-    - name: Checkout Repository
-      uses: actions/checkout@v4
-      with:
-        path: ${{ github.event.repository.name }}
-        
-    - name: Download MUSIC
-      run: |
-        cd ${GITHUB_WORKSPACE}/${REPO_NAME}/external_packages
-        ./get_music.sh
-    
-    - name: Download ISS
-      run: |
-        cd ${GITHUB_WORKSPACE}/${REPO_NAME}/external_packages
-        ./get_iSS.sh
-    
-    - name: Download FREESTREAM
-      run: |
-        cd ${GITHUB_WORKSPACE}/${REPO_NAME}/external_packages
-        ./get_freestream-milne.sh
+      - name: Checkout Repository
+        uses: actions/checkout@v4
+        with:
+          path: ${{ github.event.repository.name }}
 
-    - name: Download IPGLASMA
-      run: |
-        cd ${GITHUB_WORKSPACE}/${REPO_NAME}/external_packages
-        ./get_ipglasma.sh
+      - name: Download MUSIC
+        run: |
+          cd ${GITHUB_WORKSPACE}/${REPO_NAME}/external_packages
+          ./get_music.sh
 
-    - name: Download SMASH
-      run: |
-        cd ${GITHUB_WORKSPACE}/${REPO_NAME}/external_packages
-        ./get_smash.sh
+      - name: Download ISS
+        run: |
+          cd ${GITHUB_WORKSPACE}/${REPO_NAME}/external_packages
+          ./get_iSS.sh
 
-    - name: Build Application
-      run: |
-        cd ${GITHUB_WORKSPACE}/${REPO_NAME}
-        mkdir build
-        cd build
-        export SMASH_DIR="${GITHUB_WORKSPACE}/${REPO_NAME}/external_packages/smash/smash_code"
-        cmake .. -DUSE_MUSIC=ON -DUSE_ISS=ON -DUSE_FREESTREAM=ON -DUSE_SMASH=ON -DUSE_IPGLASMA=ON
-        make -j2
+      - name: Download FREESTREAM
+        run: |
+          cd ${GITHUB_WORKSPACE}/${REPO_NAME}/external_packages
+          ./get_freestream-milne.sh
 
-    - name: Run Unit Tests
-      run: |
-        cd ${GITHUB_WORKSPACE}/${REPO_NAME}/build/examples/unittests
-        ./causal_liquifier
-        ./fluid_dynamics
-        ./linear_interpolation
-        ./ThermPtnSampler
+      - name: Download IPGLASMA
+        run: |
+          cd ${GITHUB_WORKSPACE}/${REPO_NAME}/external_packages
+          ./get_ipglasma.sh
+
+      - name: Download SMASH
+        run: |
+          cd ${GITHUB_WORKSPACE}/${REPO_NAME}/external_packages
+          ./get_smash.sh
+
+      - name: Build Application
+        run: |
+          cd ${GITHUB_WORKSPACE}/${REPO_NAME}
+          mkdir build
+          cd build
+          export SMASH_DIR="${GITHUB_WORKSPACE}/${REPO_NAME}/external_packages/smash/smash_code"
+          cmake .. -DUSE_MUSIC=ON -DUSE_ISS=ON -DUSE_FREESTREAM=ON -DUSE_SMASH=ON -DUSE_IPGLASMA=ON
+          make -j2
+
+      - name: Run Unit Tests
+        run: |
+          cd ${GITHUB_WORKSPACE}/${REPO_NAME}/build/examples/unittests
+          ./causal_liquifier
+          ./fluid_dynamics
+          ./linear_interpolation
+          ./ThermPtnSampler

--- a/.github/workflows/test-build-external.yaml
+++ b/.github/workflows/test-build-external.yaml
@@ -15,12 +15,16 @@ env:
 
 jobs:
   build:
-    name: external packages
+    name: external packages (${{ matrix.arch }})
     runs-on: ubuntu-latest
-    
+
+    strategy:
+      matrix:
+        arch: [amd64, arm64]
+
     container:
-      image: jetscape/base:v1.13
-      options: --user root
+      image: jetscape/base:v2.0
+      options: --user root --platform=linux/${{ matrix.arch }}
       
     steps:
       

--- a/.github/workflows/test-build-nPDF.yaml
+++ b/.github/workflows/test-build-nPDF.yaml
@@ -19,7 +19,7 @@ jobs:
     runs-on: ubuntu-latest
 
     container:
-      image: jetscape/base:v1.13
+      image: jetscape/base:v2.0
       options: --user root
       
     steps:

--- a/.github/workflows/test-events-PbPb.yaml
+++ b/.github/workflows/test-events-PbPb.yaml
@@ -41,7 +41,7 @@ jobs:
       uses: actions/checkout@v4
       with:
         repository: JETSCAPE/TEST-EXAMPLES
-        ref: xscape-2.0.1
+        ref: jetscape-4.0.2
         path: TEST-EXAMPLES
       
     - name: Run Pb-Pb tests

--- a/.github/workflows/test-events-PbPb.yaml
+++ b/.github/workflows/test-events-PbPb.yaml
@@ -19,7 +19,7 @@ jobs:
     runs-on: ubuntu-latest
     
     container:
-      image: jetscape/base:v1.13
+      image: jetscape/base:v2.0
       options: --user root
       
     steps:

--- a/.github/workflows/test-events-brick.yaml
+++ b/.github/workflows/test-events-brick.yaml
@@ -18,7 +18,7 @@ jobs:
     runs-on: ubuntu-latest
 
     container:
-      image: jetscape/base:v1.13
+      image: jetscape/base:v2.0
       options: --user root
 
     steps:
@@ -45,7 +45,7 @@ jobs:
       uses: actions/checkout@v4
       with:
         repository: JETSCAPE/TEST-EXAMPLES
-        ref: jetscape-4.0.1
+        ref: jetscape-4.0.2
         path: TEST-EXAMPLES
 
     - name: Run Brick Matter Lbt tests

--- a/.github/workflows/test-events-pp.yaml
+++ b/.github/workflows/test-events-pp.yaml
@@ -41,7 +41,7 @@ jobs:
       uses: actions/checkout@v4
       with:
         repository: JETSCAPE/TEST-EXAMPLES
-        ref: xscape-2.0.1
+        ref: jetscape-4.0.2
         path: TEST-EXAMPLES
       
     - name: Run pp tests

--- a/.github/workflows/test-events-pp.yaml
+++ b/.github/workflows/test-events-pp.yaml
@@ -19,7 +19,7 @@ jobs:
     runs-on: ubuntu-latest
     
     container:
-      image: jetscape/base:v1.13
+      image: jetscape/base:v2.0
       options: --user root
       
     steps:


### PR DESCRIPTION
Since our supported Docker image will be based on Alma Linux and include multi-arch support as of the JETSCAPE 4.0.2 release, this PR adds an ARM64 runner to the automated build test.